### PR TITLE
BC-4 # implement `blinkm bmp whoami` command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,7 @@ node_modules
 
 # Optional REPL history
 .node_repl_history
+
+# temporary files
+/.blinkmrc.json
+/blinkmrc.json

--- a/commands/whoami.js
+++ b/commands/whoami.js
@@ -1,6 +1,42 @@
 'use strict';
 
-module.exports = function () {
-  console.error('not implemented');
-  process.exit(1);
+// foreign modules
+
+const pify = require('pify');
+const async = require('async');
+const elegantSpinner = require('elegant-spinner');
+const logUpdate = require('log-update');
+
+// local modules
+
+const whoami = require('../lib/whoami');
+
+// this module
+
+const pasync = pify(require('async'));
+
+function logAuthLookup (auth) {
+  const frame = elegantSpinner();
+  let timer = setInterval(() => {
+    logUpdate(`${auth.origin}: ${frame()}`);
+  }, 100);
+  return whoami.lookupUser({ auth })
+    .then((result) => {
+      logUpdate(`${auth.origin}: ${result.name} <${result.email}>`);
+      clearTimeout(timer);
+    })
+    .catch((err) => {
+      clearTimeout(timer);
+      return Promise.reject(err);
+    });
+}
+
+module.exports = function (input, flags, options) {
+  whoami.getAuthentications()
+    .then((auths) => {
+      if (auths.length) {
+        return pasync.eachSeries(auths, async.asyncify(logAuthLookup));
+      }
+      console.log('no authentication data found');
+    });
 };

--- a/lib/whoami.js
+++ b/lib/whoami.js
@@ -1,0 +1,56 @@
+'use strict';
+
+// foreign modules
+
+const request = require('request');
+
+// local modules
+
+const jsonUtils = require('./json-utils');
+const values = require('./values');
+
+// this module
+
+module.exports = {
+
+  getAuthentications (options) {
+    options = options || {};
+    const userConfigFile = values.userConfigFile(options.userConfigDir);
+    return jsonUtils.loadJsonObject(userConfigFile)
+      .catch(() => [])
+      .then((obj) => {
+        const bmp = obj.bmp || {};
+        return Object.keys(bmp)
+          .filter((origin) => !!bmp[origin].credential)
+          .map((origin) => {
+            const credential = bmp[origin].credential;
+            return { origin, credential };
+          });
+      });
+  },
+
+  lookupUser (options) {
+    options = options || {};
+    const auth = options.auth || {};
+    const jar = request.jar();
+    auth.credential.split(';').forEach((cookie) => {
+      jar.setCookie(request.cookie(cookie), auth.origin);
+    });
+    const req = options.req || request.defaults({ jar });
+    return new Promise((resolve, reject) => {
+      req(`${auth.origin}/_api/v1/dashboard`, (err, res, body) => {
+        if (err) {
+          reject(err);
+          return;
+        }
+        if (res.statusCode !== 200) {
+          reject(new Error(res.statusCode));
+          return;
+        }
+        const obj = JSON.parse(body);
+        resolve(obj.user);
+      });
+    });
+  }
+
+};

--- a/package.json
+++ b/package.json
@@ -10,12 +10,16 @@
   },
   "dependencies": {
     "appdirectory": "0.1.0",
+    "async": "1.5.2",
+    "elegant-spinner": "1.0.1",
     "find-up": "1.1.0",
     "load-json-file": "1.1.0",
+    "log-update": "1.0.2",
     "meow": "3.7.0",
     "mkdirp": "0.5.1",
     "pify": "2.3.0",
     "prompt": "0.2.14",
+    "request": "2.67.0",
     "update-notifier": "0.6.0",
     "write-json-file": "1.2.0"
   },

--- a/test/whoami.js
+++ b/test/whoami.js
@@ -1,0 +1,88 @@
+'use strict';
+
+// foreign modules
+
+const pify = require('pify');
+const temp = pify(require('temp').track());
+const test = require('ava');
+
+// local modules
+
+const auth = require('../lib/auth');
+const pkg = require('../package.json');
+const whoami = require('../lib/whoami');
+
+// this module
+
+test.beforeEach((t) => {
+  return temp.mkdir(pkg.name.replace(/\//g, '-') + '-')
+    .then((dirPath) => {
+      t.context.tempDir = dirPath;
+    })
+    .then(() => {
+      return auth.login({
+        credential: 'abcdef',
+        scope: 'https://example.com/space',
+        userConfigDir: t.context.tempDir
+      });
+    })
+    .then(() => {
+      return auth.login({
+        credential: 'ghijkl',
+        scope: 'https://otherexample.com/space',
+        userConfigDir: t.context.tempDir
+      });
+    });
+});
+
+test('getAuthentications', (t) => {
+  return whoami.getAuthentications({ userConfigDir: t.context.tempDir })
+    .then((auths) => {
+      t.same(auths, [
+        { origin: 'https://example.com', credential: 'abcdef' },
+        { origin: 'https://otherexample.com', credential: 'ghijkl' }
+      ]);
+    });
+});
+
+test('lookupUser, 200', (t) => {
+  const ORIGIN = 'https://example.com';
+  const req = (url, cb) => {
+    t.is(url, `${ORIGIN}/_api/v1/dashboard`);
+    cb(null, { statusCode: 200 }, '{}');
+  };
+  return whoami.lookupUser({
+    auth: { origin: ORIGIN, credential: 'abcdef' },
+    req
+  });
+});
+
+test('lookupUser, error', (t) => {
+  const ORIGIN = 'https://example.com';
+  const req = (url, cb) => {
+    t.is(url, `${ORIGIN}/_api/v1/dashboard`);
+    cb(new Error('blah'));
+  };
+  return whoami.lookupUser({
+    auth: { origin: ORIGIN, credential: 'abcdef' },
+    req
+  })
+    .catch((err) => {
+      t.is(err.message, 'blah');
+    });
+});
+
+test('lookupUser, 403', (t) => {
+  const ORIGIN = 'https://example.com';
+  const req = (url, cb) => {
+    t.is(url, `${ORIGIN}/_api/v1/dashboard`);
+    cb(null, { statusCode: 403 });
+  };
+  return whoami.lookupUser({
+    auth: { origin: ORIGIN, credential: 'abcdef' },
+    req
+  })
+    .catch((err) => {
+      t.is(err.message, '403');
+    });
+});


### PR DESCRIPTION
- `blinkm bmp whoami` will loop through locally-persisted authentication credentials
- for each credential, a lookup to `/_api/v1/dashboard` is performed to retrieve user details
- whilst performing look-ups, there is a spinner animation to provide visual feedback of process
- network request code in `whoami.lookupUser()` will probably be extracted out for use with other lookups in future work