### PR TITLE
BC-7 # `bm bmp deploy`, with refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,11 @@ blinkm bmp --help
 # or, shorter
 bm bmp --help
 ```
+
+
+## Environment Variables
+
+### BMP_USER_CONFIG_DIR
+
+By default, this tool stores authentication data in the user's home directory.
+You may set this variable to control this location.

--- a/README.md
+++ b/README.md
@@ -29,3 +29,8 @@ bm bmp --help
 
 By default, this tool stores authentication data in the user's home directory.
 You may set this variable to control this location.
+
+### BMP_WORKING_DIR
+
+By default, this tool looks for the .blinkmrc.json file in the current working directory, and stores project files there, too.
+You may set this variable to control this location.

--- a/README.md
+++ b/README.md
@@ -25,10 +25,18 @@ bm bmp --help
 
 ## Environment Variables
 
+
+### BMP_SCOPE
+
+By default, this tool determines your project scope by reading the .blinkmrc.json file in the current working directory or its parent directory (or its parent's parent directory, etc).
+You may set this variable instead.
+
+
 ### BMP_USER_CONFIG_DIR
 
 By default, this tool stores authentication data in the user's home directory.
 You may set this variable to control this location.
+
 
 ### BMP_WORKING_DIR
 

--- a/commands/deploy.js
+++ b/commands/deploy.js
@@ -1,6 +1,11 @@
 'use strict';
 
-module.exports = function () {
-  console.error('not implemented');
-  process.exit(1);
+// local modules
+
+const deploy = require('../lib/deploy');
+
+// this module
+
+module.exports = function (input, flags, options) {
+  return deploy.deployAll();
 };

--- a/commands/login.js
+++ b/commands/login.js
@@ -40,12 +40,10 @@ function getCredential (input) {
 }
 
 module.exports = function (input, flags, options) {
-  let projectScope;
   scope.read()
-    .then((s) => { projectScope = s; })
     .catch(() => Promise.reject(new Error('must set project scope first')))
     .then(() => getCredential(input))
-    .then((credential) => auth.login({ credential, scope: projectScope }))
+    .then((credential) => auth.login({ credential }))
     .catch((err) => {
       console.error(err);
       process.exit(1);

--- a/commands/logout.js
+++ b/commands/logout.js
@@ -3,16 +3,11 @@
 // local modules
 
 const auth = require('../lib/auth');
-const scope = require('../lib/scope');
 
 // this module
 
 module.exports = function (input, flags, options) {
-  let projectScope;
-  scope.read()
-    .then((s) => { projectScope = s; })
-    .catch(() => Promise.reject(new Error('must set project scope first')))
-    .then(() => auth.logout({ scope: projectScope }))
+  auth.logout()
     .catch((err) => {
       console.error(err);
       process.exit(1);

--- a/commands/pull.js
+++ b/commands/pull.js
@@ -3,15 +3,9 @@
 // local modules
 
 const pull = require('../lib/pull');
-const whoami = require('../lib/whoami');
 
 // this module
 
 module.exports = function (input, flags, options) {
-  let auth;
-  whoami.getAuthentication()
-    .then((a) => {
-      auth = a;
-      return pull.pullAnswerSpace({ auth });
-    });
+  return pull.pullAnswerSpace();
 };

--- a/commands/pull.js
+++ b/commands/pull.js
@@ -3,21 +3,15 @@
 // local modules
 
 const pull = require('../lib/pull');
-const scope = require('../lib/scope');
 const whoami = require('../lib/whoami');
 
 // this module
 
 module.exports = function (input, flags, options) {
-  let projectScope;
   let auth;
-  scope.read()
-    .then((s) => {
-      projectScope = s;
-      return whoami.getAuthentication({ scope: projectScope });
-    })
+  whoami.getAuthentication()
     .then((a) => {
       auth = a;
-      return pull.pullAnswerSpace({ auth, scope: projectScope });
+      return pull.pullAnswerSpace({ auth });
     });
 };

--- a/commands/whoami.js
+++ b/commands/whoami.js
@@ -9,20 +9,21 @@ const logUpdate = require('log-update');
 
 // local modules
 
+const auth = require('../lib/auth');
 const whoami = require('../lib/whoami');
 
 // this module
 
 const pasync = pify(require('async'));
 
-function logAuthLookup (auth) {
+function logAuthLookup (options) {
   const frame = elegantSpinner();
   let timer = setInterval(() => {
-    logUpdate(`${auth.origin}: ${frame()}`);
+    logUpdate(`${options.origin}: ${frame()}`);
   }, 100);
-  return whoami.lookupUser({ auth })
+  return whoami.lookupUser()
     .then((result) => {
-      logUpdate(`${auth.origin}: ${result.name} <${result.email}>`);
+      logUpdate(`${options.origin}: ${result.name} <${result.email}>`);
       clearTimeout(timer);
     })
     .catch((err) => {
@@ -32,7 +33,7 @@ function logAuthLookup (auth) {
 }
 
 module.exports = function (input, flags, options) {
-  whoami.getAuthentications()
+  auth.readAll()
     .then((auths) => {
       if (auths.length) {
         return pasync.eachSeries(auths, async.asyncify(logAuthLookup));

--- a/lib/api.js
+++ b/lib/api.js
@@ -29,23 +29,25 @@ function getDashboard () {
     }));
 }
 
-function getResource (options) {
-  options = options || {};
-  assertTypeAndId(options);
-  assertKnownType(options);
+function decorateWithOptionsAssertions (fn) {
+  return (options) => {
+    options = options || {};
+    assertTypeAndId(options);
+    assertKnownType(options);
 
+    return fn(options);
+  };
+}
+
+const getResource = decorateWithOptionsAssertions((options) => {
   return auth.read()
     .then((a) => httpUtils.sendRequest({
       credential: a.credential,
       url: `${a.origin}/_api/v1/${options.type}/${options.id}`
     }));
-}
+});
 
-function putResource (options) {
-  options = options || {};
-  assertTypeAndId(options);
-  assertKnownType(options);
-
+const putResource = decorateWithOptionsAssertions((options) => {
   const body = {};
   body[options.type] = options.data;
   return auth.read()
@@ -55,7 +57,7 @@ function putResource (options) {
       method: 'PUT',
       url: `${a.origin}/_api/v1/${options.type}/${options.id}`
     }));
-}
+});
 
 module.exports = {
   getDashboard,

--- a/lib/api.js
+++ b/lib/api.js
@@ -9,9 +9,21 @@ const httpUtils = require('./utils/http');
 
 const TYPES = [ 'answerspaces', 'interactions' ];
 
+function assertTypeAndId (options) {
+  if (!options.type || !options.id) {
+    throw new TypeError('"type" and "id" must be provided');
+  }
+}
+
+function assertKnownType (options) {
+  if (!~TYPES.indexOf(options.type)) {
+    throw new TypeError(`"${options.type}" is not a known type`);
+  }
+}
+
 function getDashboard () {
   return auth.read()
-    .then((a) => httpUtils.request({
+    .then((a) => httpUtils.sendRequest({
       credential: a.credential,
       url: `${a.origin}/_api/v1/dashboard`
     }));
@@ -19,16 +31,28 @@ function getDashboard () {
 
 function getResource (options) {
   options = options || {};
-  if (!options.type || !options.id) {
-    throw new TypeError('"type" and "id" must be provided');
-  }
-  if (!~TYPES.indexOf(options.type)) {
-    throw new TypeError(`"${options.type}" is not a known type`);
-  }
+  assertTypeAndId(options);
+  assertKnownType(options);
 
   return auth.read()
-    .then((a) => httpUtils.request({
+    .then((a) => httpUtils.sendRequest({
       credential: a.credential,
+      url: `${a.origin}/_api/v1/${options.type}/${options.id}`
+    }));
+}
+
+function putResource (options) {
+  options = options || {};
+  assertTypeAndId(options);
+  assertKnownType(options);
+
+  const body = {};
+  body[options.type] = options.data;
+  return auth.read()
+    .then((a) => httpUtils.sendRequest({
+      body,
+      credential: a.credential,
+      method: 'PUT',
       url: `${a.origin}/_api/v1/${options.type}/${options.id}`
     }));
 }
@@ -36,5 +60,6 @@ function getResource (options) {
 module.exports = {
   getDashboard,
   getResource,
+  putResource,
   TYPES
 };

--- a/lib/api.js
+++ b/lib/api.js
@@ -1,0 +1,41 @@
+'use strict';
+
+// local modules
+
+const httpUtils = require('./utils/http');
+
+// this module
+
+const TYPES = [ 'answerspaces', 'interactions' ];
+
+function getDashboard (options) {
+  options = options || {};
+  const auth = options.auth || {};
+
+  return httpUtils.request({
+    credential: auth.credential,
+    url: `${auth.origin}/_api/v1/dashboard`
+  });
+}
+
+function getResource (options) {
+  options = options || {};
+  if (!options.type || !options.id) {
+    throw new TypeError('"type" and "id" must be provided');
+  }
+  if (!~TYPES.indexOf(options.type)) {
+    throw new TypeError(`"${options.type}" is not a known type`);
+  }
+
+  const auth = options.auth || {};
+  return httpUtils.request({
+    credential: auth.credential,
+    url: `${auth.origin}/_api/v1/${options.type}/${options.id}`
+  });
+}
+
+module.exports = {
+  getDashboard,
+  getResource,
+  TYPES
+};

--- a/lib/api.js
+++ b/lib/api.js
@@ -2,20 +2,19 @@
 
 // local modules
 
+const auth = require('./auth');
 const httpUtils = require('./utils/http');
 
 // this module
 
 const TYPES = [ 'answerspaces', 'interactions' ];
 
-function getDashboard (options) {
-  options = options || {};
-  const auth = options.auth || {};
-
-  return httpUtils.request({
-    credential: auth.credential,
-    url: `${auth.origin}/_api/v1/dashboard`
-  });
+function getDashboard () {
+  return auth.read()
+    .then((a) => httpUtils.request({
+      credential: a.credential,
+      url: `${a.origin}/_api/v1/dashboard`
+    }));
 }
 
 function getResource (options) {
@@ -27,11 +26,11 @@ function getResource (options) {
     throw new TypeError(`"${options.type}" is not a known type`);
   }
 
-  const auth = options.auth || {};
-  return httpUtils.request({
-    credential: auth.credential,
-    url: `${auth.origin}/_api/v1/${options.type}/${options.id}`
-  });
+  return auth.read()
+    .then((a) => httpUtils.request({
+      credential: a.credential,
+      url: `${a.origin}/_api/v1/${options.type}/${options.id}`
+    }));
 }
 
 module.exports = {

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -11,76 +11,116 @@ const mkdirp = pify(require('mkdirp'));
 
 // local modules
 
-const getOrigin = require('./utils/url').getOrigin;
 const jsonUtils = require('./utils/json');
 const scope = require('./scope');
+const urlUtils = require('./utils/url');
 const values = require('./values');
 
 // this module
 
 const fsp = pify(fs);
 
-module.exports = {
+function login (options) {
+  options = options || {};
 
-  login (options) {
-    options = options || {};
-
-    let projectScope;
-    return scope.read()
-      .then((s) => {
-        projectScope = s;
-      })
-      .catch(() => {
-        throw new Error('must set project scope first');
-      })
-      .then(() => mkdirp(values.USER_CONFIG_DIR))
-      .then(() => {
-        return jsonUtils.updateJson(values.USER_CONFIG_FILE, (cfg) => {
-          cfg.bmp = cfg.bmp || {};
-          cfg.bmp[getOrigin(projectScope)] = {
-            credential: options.credential
-          };
-          return cfg;
-        }, {
-          mode: 0o600
-        });
+  let projectScope;
+  return scope.read()
+    .then((s) => {
+      projectScope = s;
+    })
+    .catch(() => {
+      throw new Error('must set project scope first');
+    })
+    .then(() => mkdirp(values.USER_CONFIG_DIR))
+    .then(() => {
+      return jsonUtils.updateJson(values.USER_CONFIG_FILE, (cfg) => {
+        cfg.bmp = cfg.bmp || {};
+        const origin = urlUtils.getOrigin(projectScope);
+        cfg.bmp[origin] = {
+          credential: options.credential
+        };
+        return cfg;
+      }, {
+        mode: 0o600
       });
-  },
+    });
+}
 
-  logout (options) {
-    options = options || {};
-    const EXITEARLYHACK = 'EXITEARLYHACK';
+function logout () {
+  const EXITEARLYHACK = 'EXITEARLYHACK';
 
-    let projectScope;
-    return scope.read()
-      .then((s) => {
-        projectScope = s;
-      })
-      .catch(() => {
-        throw new Error('must set project scope first');
-      })
-      .then(() => fsp.access(values.USER_CONFIG_FILE, fs.F_OK))
-      .catch(() => {
-        return Promise.reject(new Error('EXITEARLYHACK'));
-      })
-      .then(() => fsp.access(values.USER_CONFIG_FILE, fs.R_OK | fs.W_OK))
-      .then(() => {
-        return jsonUtils.updateJson(values.USER_CONFIG_FILE, (cfg) => {
-          cfg.bmp = cfg.bmp || {};
-          const origin = getOrigin(projectScope);
-          if (cfg.bmp[origin]) {
-            delete cfg.bmp[origin].credential;
-          }
-          return cfg;
-        }, {
-          mode: 0o600
-        });
-      })
-      .catch((err) => {
-        if (err.message !== EXITEARLYHACK) {
-          return Promise.reject(err);
+  let projectScope;
+  return scope.read()
+    .then((s) => {
+      projectScope = s;
+    })
+    .catch(() => {
+      throw new Error('must set project scope first');
+    })
+    .then(() => fsp.access(values.USER_CONFIG_FILE, fs.F_OK))
+    .catch(() => {
+      return Promise.reject(new Error('EXITEARLYHACK'));
+    })
+    .then(() => fsp.access(values.USER_CONFIG_FILE, fs.R_OK | fs.W_OK))
+    .then(() => {
+      return jsonUtils.updateJson(values.USER_CONFIG_FILE, (cfg) => {
+        cfg.bmp = cfg.bmp || {};
+        const origin = urlUtils.getOrigin(projectScope);
+        if (cfg.bmp[origin]) {
+          delete cfg.bmp[origin].credential;
         }
+        return cfg;
+      }, {
+        mode: 0o600
       });
-  }
+    })
+    .catch((err) => {
+      if (err.message !== EXITEARLYHACK) {
+        return Promise.reject(err);
+      }
+    });
+}
 
+function readAll () {
+  return jsonUtils.loadJsonObject(values.USER_CONFIG_FILE)
+    .catch((err) => {
+      if (err.code === 'ENOENT') {
+        // missing file = not authenticated, which we handle further down
+        return {};
+      }
+      // throw every other error, e.g. corrupt file, bad permissions, etc
+      throw err;
+    })
+    .then((obj) => {
+      const bmp = obj.bmp || {};
+      return Object.keys(bmp)
+        .filter((origin) => !!bmp[origin].credential)
+        .map((origin) => {
+          const credential = bmp[origin].credential;
+          return { origin, credential };
+        });
+    });
+}
+
+function read () {
+  let origin;
+  return scope.read()
+    .then((projectScope) => {
+      origin = urlUtils.getOrigin(urlUtils.toHTTPS(projectScope) || '');
+    })
+    .then(() => readAll())
+    .then((auths) => {
+      const matches = auths.filter((a) => a.origin === origin);
+      if (matches.length) {
+        return matches[0];
+      }
+      throw new Error(`not yet logged in for scope origin: ${origin}`);
+    });
+}
+
+module.exports = {
+  login,
+  logout,
+  read,
+  readAll
 };

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -108,7 +108,7 @@ function read () {
     .then((projectScope) => {
       origin = urlUtils.getOrigin(urlUtils.toHTTPS(projectScope) || '');
     })
-    .then(() => readAll())
+    .then(readAll)
     .then((auths) => {
       const matches = auths.filter((a) => a.origin === origin);
       if (matches.length) {

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -13,6 +13,7 @@ const mkdirp = pify(require('mkdirp'));
 
 const getOrigin = require('./utils/url').getOrigin;
 const jsonUtils = require('./utils/json');
+const scope = require('./scope');
 const values = require('./values');
 
 // this module
@@ -23,14 +24,20 @@ module.exports = {
 
   login (options) {
     options = options || {};
-    if (!options.scope) {
-      return Promise.reject(new Error('must set project scope first'));
-    }
-    return mkdirp(values.USER_CONFIG_DIR)
+
+    let projectScope;
+    return scope.read()
+      .then((s) => {
+        projectScope = s;
+      })
+      .catch(() => {
+        throw new Error('must set project scope first');
+      })
+      .then(() => mkdirp(values.USER_CONFIG_DIR))
       .then(() => {
         return jsonUtils.updateJson(values.USER_CONFIG_FILE, (cfg) => {
           cfg.bmp = cfg.bmp || {};
-          cfg.bmp[getOrigin(options.scope)] = {
+          cfg.bmp[getOrigin(projectScope)] = {
             credential: options.credential
           };
           return cfg;
@@ -42,11 +49,17 @@ module.exports = {
 
   logout (options) {
     options = options || {};
-    if (!options.scope) {
-      return Promise.reject(new Error('must set project scope first'));
-    }
     const EXITEARLYHACK = 'EXITEARLYHACK';
-    return fsp.access(values.USER_CONFIG_FILE, fs.F_OK)
+
+    let projectScope;
+    return scope.read()
+      .then((s) => {
+        projectScope = s;
+      })
+      .catch(() => {
+        throw new Error('must set project scope first');
+      })
+      .then(() => fsp.access(values.USER_CONFIG_FILE, fs.F_OK))
       .catch(() => {
         return Promise.reject(new Error('EXITEARLYHACK'));
       })
@@ -54,8 +67,9 @@ module.exports = {
       .then(() => {
         return jsonUtils.updateJson(values.USER_CONFIG_FILE, (cfg) => {
           cfg.bmp = cfg.bmp || {};
-          if (cfg.bmp[getOrigin(options.scope)]) {
-            delete cfg.bmp[getOrigin(options.scope)].credential;
+          const origin = getOrigin(projectScope);
+          if (cfg.bmp[origin]) {
+            delete cfg.bmp[origin].credential;
           }
           return cfg;
         }, {

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -26,11 +26,9 @@ module.exports = {
     if (!options.scope) {
       return Promise.reject(new Error('must set project scope first'));
     }
-    const userConfigDir = options.userConfigDir || values.USER_CONFIG_DIR;
-    const userConfigFile = values.userConfigFile(options.userConfigDir);
-    return mkdirp(userConfigDir)
+    return mkdirp(values.USER_CONFIG_DIR)
       .then(() => {
-        return jsonUtils.updateJson(userConfigFile, (cfg) => {
+        return jsonUtils.updateJson(values.USER_CONFIG_FILE, (cfg) => {
           cfg.bmp = cfg.bmp || {};
           cfg.bmp[getOrigin(options.scope)] = {
             credential: options.credential
@@ -47,15 +45,14 @@ module.exports = {
     if (!options.scope) {
       return Promise.reject(new Error('must set project scope first'));
     }
-    const userConfigFile = values.userConfigFile(options.userConfigDir);
     const EXITEARLYHACK = 'EXITEARLYHACK';
-    return fsp.access(userConfigFile, fs.F_OK)
+    return fsp.access(values.USER_CONFIG_FILE, fs.F_OK)
       .catch(() => {
         return Promise.reject(new Error('EXITEARLYHACK'));
       })
-      .then(() => fsp.access(userConfigFile, fs.R_OK | fs.W_OK))
+      .then(() => fsp.access(values.USER_CONFIG_FILE, fs.R_OK | fs.W_OK))
       .then(() => {
-        return jsonUtils.updateJson(userConfigFile, (cfg) => {
+        return jsonUtils.updateJson(values.USER_CONFIG_FILE, (cfg) => {
           cfg.bmp = cfg.bmp || {};
           if (cfg.bmp[getOrigin(options.scope)]) {
             delete cfg.bmp[getOrigin(options.scope)].credential;

--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -1,0 +1,63 @@
+'use strict';
+
+// Node.js built-ins
+
+const fs = require('fs');
+const path = require('path');
+
+// foreign modules
+
+const async = require('async');
+const pify = require('pify');
+const readJsonFiles = require('@blinkmobile/json-as-files').readData;
+
+// local modules
+
+const api = require('./api');
+const resource = require('./resource');
+
+// this module
+
+const fsp = pify(fs);
+const asyncp = pify(async);
+
+function deployAnswerSpace (options) {
+  return readJsonFiles({ filePath: path.join(options.cwd, 'answerSpace.json') })
+    .then((data) => resource.fixAnswerSpace(data))
+    .then((data) => api.putResource({ id: data.id, type: 'answerspaces', data }));
+}
+
+function deployInteraction (options) {
+  const filePath = path.join(options.cwd, 'interactions', options.entry, `${options.entry}.json`);
+  return readJsonFiles({ filePath })
+    .then((data) => resource.fixInteraction(data))
+    .then((data) => api.putResource({ id: data.id, type: 'interactions', data }));
+}
+
+function deployInteractions (options) {
+  const cwd = options.cwd;
+  return fsp.readdir(path.join(cwd, 'interactions'))
+    .catch((err) => {
+      if (err.code === 'ENOENT') {
+        // it's not an error condition if we don't have any interactions
+        return [];
+      }
+      throw err;
+    })
+    .then((entries) => asyncp.eachSeries(entries, async.asyncify((entry) => {
+      return deployInteraction({ cwd, entry });
+    })));
+}
+
+function deployAll () {
+  const cwd = process.env.BMP_WORKING_DIR || process.cwd();
+
+  return Promise.all([
+    deployAnswerSpace({ cwd }),
+    deployInteractions({ cwd })
+  ]);
+}
+
+module.exports = {
+  deployAll
+};

--- a/lib/pull.js
+++ b/lib/pull.js
@@ -14,6 +14,7 @@ const writeJsonFiles = require('@blinkmobile/json-as-files').writeData;
 // local modules
 
 const api = require('./api');
+const resource = require('./resource');
 const values = require('./values');
 
 // this module
@@ -30,8 +31,7 @@ function pullAnswerSpace () {
     .then((obj) => {
       const data = Object.assign({}, obj.answerspaces);
       interactions = data.links.interactions || [];
-      delete data.links;
-      delete data.sitemap;
+      resource.fixAnswerSpace(data);
       // persist the real data, honoring the $file placeholders
       return writeJsonFiles({
         filePath: path.join(cwd, 'answerSpace.json'),
@@ -52,7 +52,7 @@ function pullAnswerSpace () {
         })
         .then(() => {
           const data = Object.assign({}, obj);
-          delete data.links;
+          resource.fixInteraction(data);
           // persist the real data, honoring the $file placeholders
           return writeJsonFiles({
             filePath: path.join(cwd, 'interactions', data.name, `${data.name}.json`),

--- a/lib/pull.js
+++ b/lib/pull.js
@@ -21,7 +21,7 @@ const values = require('./values');
 function pullAnswerSpace (options) {
   options = options || {};
   const auth = options.auth || {};
-  const cwd = options.cwd || process.cwd();
+  const cwd = process.env.BMP_WORKING_DIR || process.cwd();
 
   let interactions;
   // persist the default template with $file placeholders

--- a/lib/pull.js
+++ b/lib/pull.js
@@ -18,17 +18,15 @@ const values = require('./values');
 
 // this module
 
-function pullAnswerSpace (options) {
-  options = options || {};
-  const auth = options.auth || {};
+function pullAnswerSpace () {
   const cwd = process.env.BMP_WORKING_DIR || process.cwd();
 
   let interactions;
   // persist the default template with $file placeholders
   return writeJson(path.join(cwd, 'answerSpace.json'), values.defaultAnswerSpaceConfig('answerSpace'))
-    .then(() => api.getDashboard(options))
+    .then(() => api.getDashboard())
     .then((obj) => obj.answerSpace.id)
-    .then((id) => api.getResource({ auth, id, type: 'answerspaces' }))
+    .then((id) => api.getResource({ id, type: 'answerspaces' }))
     .then((obj) => {
       const data = Object.assign({}, obj.answerspaces);
       interactions = data.links.interactions || [];
@@ -44,7 +42,7 @@ function pullAnswerSpace (options) {
     .then(() => Promise.all(interactions.map((id) => {
       let name;
       let obj;
-      return api.getResource({ auth, id, type: 'interactions' })
+      return api.getResource({ id, type: 'interactions' })
         .then((result) => {
           obj = result.interactions;
           name = obj.name;

--- a/lib/pull.js
+++ b/lib/pull.js
@@ -13,38 +13,10 @@ const writeJsonFiles = require('@blinkmobile/json-as-files').writeData;
 
 // local modules
 
-const httpUtils = require('./utils/http');
+const api = require('./api');
 const values = require('./values');
 
 // this module
-
-const TYPES = [ 'answerspaces', 'interactions' ];
-
-function getDashboard (options) {
-  options = options || {};
-  const auth = options.auth || {};
-
-  return httpUtils.request({
-    credential: auth.credential,
-    url: `${auth.origin}/_api/v1/dashboard`
-  });
-}
-
-function getJson (options) {
-  options = options || {};
-  if (!options.type || !options.id) {
-    throw new TypeError('"type" and "id" must be provided');
-  }
-  if (!~TYPES.indexOf(options.type)) {
-    throw new TypeError(`"${options.type}" is not a known type`);
-  }
-
-  const auth = options.auth || {};
-  return httpUtils.request({
-    credential: auth.credential,
-    url: `${auth.origin}/_api/v1/${options.type}/${options.id}`
-  });
-}
 
 function pullAnswerSpace (options) {
   options = options || {};
@@ -54,9 +26,9 @@ function pullAnswerSpace (options) {
   let interactions;
   // persist the default template with $file placeholders
   return writeJson(path.join(cwd, 'answerSpace.json'), values.defaultAnswerSpaceConfig('answerSpace'))
-    .then(() => getDashboard(options))
+    .then(() => api.getDashboard(options))
     .then((obj) => obj.answerSpace.id)
-    .then((id) => getJson({ auth, id, type: 'answerspaces' }))
+    .then((id) => api.getResource({ auth, id, type: 'answerspaces' }))
     .then((obj) => {
       const data = Object.assign({}, obj.answerspaces);
       interactions = data.links.interactions || [];
@@ -72,7 +44,7 @@ function pullAnswerSpace (options) {
     .then(() => Promise.all(interactions.map((id) => {
       let name;
       let obj;
-      return getJson({ auth, id, type: 'interactions' })
+      return api.getResource({ auth, id, type: 'interactions' })
         .then((result) => {
           obj = result.interactions;
           name = obj.name;
@@ -93,7 +65,5 @@ function pullAnswerSpace (options) {
 }
 
 module.exports = {
-  getDashboard,
-  getJson,
   pullAnswerSpace
 };

--- a/lib/resource.js
+++ b/lib/resource.js
@@ -1,0 +1,27 @@
+'use strict';
+
+function fixResource (data) {
+  delete data.created_time;
+  delete data.links;
+  delete data.modified_time;
+  return data;
+}
+
+function fixAnswerSpace (data) {
+  fixResource(data);
+  delete data.sitemap;
+  return data;
+}
+
+function fixInteraction (data) {
+  fixResource(data);
+  if (typeof data.order !== 'number') {
+    delete data.order;
+  }
+  return data;
+}
+
+module.exports = {
+  fixAnswerSpace,
+  fixInteraction
+};

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -17,7 +17,8 @@ const jsonUtils = require('./utils/json');
 // this module
 
 function findConfig (options) {
-  return findUp(CONFIG_FILE, { cwd: options.cwd || process.cwd() })
+  const cwd = process.env.BMP_WORKING_DIR || process.cwd();
+  return findUp(CONFIG_FILE, { cwd })
     .then((filePath) => {
       if (!filePath) {
         return Promise.reject(new Error(`${CONFIG_FILE} not found`));
@@ -51,8 +52,9 @@ module.exports = {
     let filePath;
     return findConfig(options)
       .catch(() => {
+        const cwd = process.env.BMP_WORKING_DIR || process.cwd();
         // not found, so assume we want to make one in cwd
-        return path.join(options.cwd || process.cwd(), CONFIG_FILE);
+        return path.join(cwd, CONFIG_FILE);
       })
       .then((fp) => {
         filePath = fp;

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -16,7 +16,7 @@ const jsonUtils = require('./utils/json');
 
 // this module
 
-function findConfig (options) {
+function findConfig () {
   const cwd = process.env.BMP_WORKING_DIR || process.cwd();
   return findUp(CONFIG_FILE, { cwd })
     .then((filePath) => {
@@ -31,9 +31,15 @@ module.exports = {
 
   CONFIG_FILE,
 
-  read (options) {
-    options = options || {};
-    return findConfig(options)
+  read () {
+    if (process.env.BMP_SCOPE) {
+      if (!isURL(process.env.BMP_SCOPE)) {
+        return Promise.reject(new TypeError(`"${process.env.BMP_SCOPE}" is not a valid URL`));
+      }
+      return Promise.resolve(process.env.BMP_SCOPE);
+    }
+
+    return findConfig()
       .then((filePath) => jsonUtils.loadJsonObject(filePath))
       .then((cfg) => {
         if (!cfg.bmp || !cfg.bmp.scope) {
@@ -44,13 +50,12 @@ module.exports = {
   },
 
   write (options) {
-    options = options || {};
     if (!isURL(options.scope)) {
       return Promise.reject(new TypeError(`"${options.scope}" is not a valid URL`));
     }
 
     let filePath;
-    return findConfig(options)
+    return findConfig()
       .catch(() => {
         const cwd = process.env.BMP_WORKING_DIR || process.cwd();
         // not found, so assume we want to make one in cwd

--- a/lib/utils/http.js
+++ b/lib/utils/http.js
@@ -6,32 +6,38 @@ const urlUtils = require('./url');
 
 // this module
 
+function makeRequester (options) {
+  options = options || {};
+
+  // requesting foreign module at call time to assist with mocking
+  const request = require('request');
+
+  if (!request.jar || !request.defaults) {
+    return request; // probably mocking request, so just return the mock
+  }
+
+  const credential = options.credential || '';
+  const jar = request.jar();
+  credential.split(';').forEach((cookie) => {
+    jar.setCookie(request.cookie(cookie), urlUtils.getOrigin(options.url));
+  });
+  return request.defaults({ jar });
+}
+
 module.exports = {
+
+  makeRequester,
 
   request (options) {
     options = options || {};
     if (!urlUtils.isURL(options.url)) {
       return Promise.reject(new TypeError('expected valid URL'));
     }
-    const credential = options.credential || '';
 
-    const jarredRequest = (() => {
-      // requesting foreign module at call time to assist with mocking
-      const request = require('request');
-
-      if (!request.jar || !request.defaults) {
-        return request; // probably mocking request, so just return the mock
-      }
-
-      const jar = request.jar();
-      credential.split(';').forEach((cookie) => {
-        jar.setCookie(request.cookie(cookie), urlUtils.getOrigin(options.url));
-      });
-      return request.defaults({ jar });
-    })();
+    const requester = makeRequester(options);
 
     return new Promise((resolve, reject) => {
-      jarredRequest(urlUtils.toHTTPS(options.url), (err, res, body) => {
+      requester(urlUtils.toHTTPS(options.url), (err, res, body) => {
         if (err) {
           reject(err);
           return;

--- a/lib/utils/http.js
+++ b/lib/utils/http.js
@@ -19,36 +19,44 @@ function makeRequester (options) {
   const credential = options.credential || '';
   const jar = request.jar();
   credential.split(';').forEach((cookie) => {
-    jar.setCookie(request.cookie(cookie), urlUtils.getOrigin(options.url));
+    jar.setCookie(request.cookie(cookie), options.origin);
   });
-  return request.defaults({ jar });
+  return request.defaults({ jar, json: true });
 }
 
-module.exports = {
+let requester;
 
-  makeRequester,
-
-  request (options) {
-    options = options || {};
-    if (!urlUtils.isURL(options.url)) {
-      return Promise.reject(new TypeError('expected valid URL'));
-    }
-
-    const requester = makeRequester(options);
-
-    return new Promise((resolve, reject) => {
-      requester(urlUtils.toHTTPS(options.url), (err, res, body) => {
-        if (err) {
-          reject(err);
-          return;
-        }
-        if (res.statusCode !== 200) {
-          reject(new Error(res.statusCode));
-          return;
-        }
-        resolve(JSON.parse(body));
-      });
-    });
+function sendRequest (options) {
+  options = options || {};
+  if (!urlUtils.isURL(options.url)) {
+    return Promise.reject(new TypeError('expected valid URL'));
   }
 
-};
+  options.url = urlUtils.toHTTPS(options.url);
+
+  requester = requester || makeRequester({
+    credential: options.credential,
+    origin: urlUtils.getOrigin(options.url)
+  });
+
+  return new Promise((resolve, reject) => {
+    requester({
+      body: options.body,
+      method: options.method || 'GET',
+      url: options.url
+    }, (err, res, body) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+      if (res.statusCode !== 200) {
+        reject(new Error(res.statusCode));
+        console.error(options.url, res.statusCode, body);
+        return;
+      }
+      resolve(typeof body === 'string' ? JSON.parse(body) : body);
+    });
+  });
+}
+
+module.exports = { sendRequest };

--- a/lib/utils/url.js
+++ b/lib/utils/url.js
@@ -16,13 +16,9 @@ function isURL (string) {
 }
 
 function getOrigin (string) {
-  try {
-    let result = url.parse(string);
-    let host = result.host || `${result.hostname}:${result.port}`;
-    return `${result.protocol}//${host}`;
-  } catch (err) {
-    return '';
-  }
+  let result = url.parse(string);
+  let host = result.host || `${result.hostname}:${result.port}`;
+  return `${result.protocol}//${host}`;
 }
 
 function toHTTPS (string) {

--- a/lib/values.js
+++ b/lib/values.js
@@ -70,15 +70,24 @@ function defaultInteractionConfig (base) {
   return obj;
 }
 
-function userConfigFile (userConfigDir) {
-  return path.join(userConfigDir || dirs.userConfig(), 'blinkmrc.json');
-}
-
 module.exports = {
   CONFIG_FILE,
-  USER_CONFIG_DIR,
   defaultAnswerSpaceConfig,
   defaultConfig,
-  defaultInteractionConfig,
-  userConfigFile
+  defaultInteractionConfig
 };
+
+Object.defineProperty(module.exports, 'USER_CONFIG_DIR', {
+  enumerable: true,
+  get () {
+    return process.env.BMP_USER_CONFIG_DIR || USER_CONFIG_DIR;
+  }
+});
+
+Object.defineProperty(module.exports, 'USER_CONFIG_FILE', {
+  enumerable: true,
+  get () {
+    const dirPath = process.env.BMP_USER_CONFIG_DIR || USER_CONFIG_DIR;
+    return path.join(dirPath, 'blinkmrc.json');
+  }
+});

--- a/lib/whoami.js
+++ b/lib/whoami.js
@@ -2,8 +2,8 @@
 
 // local modules
 
+const api = require('./api');
 const jsonUtils = require('./utils/json');
-const pull = require('./pull');
 const urlUtils = require('./utils/url');
 const values = require('./values');
 
@@ -58,7 +58,7 @@ module.exports = {
   },
 
   lookupUser (options) {
-    return pull.getDashboard(options)
+    return api.getDashboard(options)
       .then((obj) => obj.user);
   }
 

--- a/lib/whoami.js
+++ b/lib/whoami.js
@@ -4,60 +4,59 @@
 
 const api = require('./api');
 const jsonUtils = require('./utils/json');
+const scope = require('./scope');
 const urlUtils = require('./utils/url');
 const values = require('./values');
 
 // this module
 
+function getAuthentications (options) {
+  options = options || {};
+  return jsonUtils.loadJsonObject(values.USER_CONFIG_FILE)
+    .catch((err) => {
+      if (err.code === 'ENOENT') {
+        // missing file = not authenticated, which we handle further down
+        return {};
+      }
+      // throw every other error, e.g. corrupt file, bad permissions, etc
+      throw err;
+    })
+    .then((obj) => {
+      const bmp = obj.bmp || {};
+      return Object.keys(bmp)
+        .filter((origin) => !!bmp[origin].credential)
+        .map((origin) => {
+          const credential = bmp[origin].credential;
+          return { origin, credential };
+        });
+    });
+}
+
+function getAuthentication (options) {
+  options = options || {};
+
+  let origin;
+  return scope.read()
+    .then((projectScope) => {
+      origin = urlUtils.getOrigin(projectScope || '');
+    })
+    .then(() => getAuthentications(options))
+    .then((auths) => {
+      const matches = auths.filter((auth) => auth.origin === origin);
+      if (matches.length) {
+        return matches[0];
+      }
+      throw new Error(`not yet logged in for scope origin: ${origin}`);
+    });
+}
+
+function lookupUser (options) {
+  return api.getDashboard(options)
+    .then((obj) => obj.user);
+}
+
 module.exports = {
-
-  getAuthentication (options) {
-    options = options || {};
-    const origin = urlUtils.getOrigin(options.scope || '');
-    return jsonUtils.loadJsonObject(values.USER_CONFIG_FILE)
-      .catch((err) => {
-        if (err.code === 'ENOENT') {
-          // missing file = not authenticated, which we handle further down
-          return {};
-        }
-        // throw every other error, e.g. corrupt file, bad permissions, etc
-        throw err;
-      })
-      .then((obj) => {
-        const bmp = obj.bmp || {};
-        bmp[origin] = bmp[origin] || {};
-        if (!bmp[origin].credential) {
-          throw new Error(`not yet logged in for scope: ${origin}`);
-        }
-        return { origin, credential: bmp[origin].credential };
-      });
-  },
-
-  getAuthentications (options) {
-    options = options || {};
-    return jsonUtils.loadJsonObject(values.USER_CONFIG_FILE)
-      .catch((err) => {
-        if (err.code === 'ENOENT') {
-          // missing file = not authenticated, which we handle further down
-          return {};
-        }
-        // throw every other error, e.g. corrupt file, bad permissions, etc
-        throw err;
-      })
-      .then((obj) => {
-        const bmp = obj.bmp || {};
-        return Object.keys(bmp)
-          .filter((origin) => !!bmp[origin].credential)
-          .map((origin) => {
-            const credential = bmp[origin].credential;
-            return { origin, credential };
-          });
-      });
-  },
-
-  lookupUser (options) {
-    return api.getDashboard(options)
-      .then((obj) => obj.user);
-  }
-
+  getAuthentication,
+  getAuthentications,
+  lookupUser
 };

--- a/lib/whoami.js
+++ b/lib/whoami.js
@@ -3,60 +3,14 @@
 // local modules
 
 const api = require('./api');
-const jsonUtils = require('./utils/json');
-const scope = require('./scope');
-const urlUtils = require('./utils/url');
-const values = require('./values');
 
 // this module
 
-function getAuthentications (options) {
-  options = options || {};
-  return jsonUtils.loadJsonObject(values.USER_CONFIG_FILE)
-    .catch((err) => {
-      if (err.code === 'ENOENT') {
-        // missing file = not authenticated, which we handle further down
-        return {};
-      }
-      // throw every other error, e.g. corrupt file, bad permissions, etc
-      throw err;
-    })
-    .then((obj) => {
-      const bmp = obj.bmp || {};
-      return Object.keys(bmp)
-        .filter((origin) => !!bmp[origin].credential)
-        .map((origin) => {
-          const credential = bmp[origin].credential;
-          return { origin, credential };
-        });
-    });
-}
-
-function getAuthentication (options) {
-  options = options || {};
-
-  let origin;
-  return scope.read()
-    .then((projectScope) => {
-      origin = urlUtils.getOrigin(projectScope || '');
-    })
-    .then(() => getAuthentications(options))
-    .then((auths) => {
-      const matches = auths.filter((auth) => auth.origin === origin);
-      if (matches.length) {
-        return matches[0];
-      }
-      throw new Error(`not yet logged in for scope origin: ${origin}`);
-    });
-}
-
-function lookupUser (options) {
-  return api.getDashboard(options)
+function lookupUser () {
+  return api.getDashboard()
     .then((obj) => obj.user);
 }
 
 module.exports = {
-  getAuthentication,
-  getAuthentications,
   lookupUser
 };

--- a/lib/whoami.js
+++ b/lib/whoami.js
@@ -13,9 +13,8 @@ module.exports = {
 
   getAuthentication (options) {
     options = options || {};
-    const userConfigFile = values.userConfigFile(options.userConfigDir);
     const origin = urlUtils.getOrigin(options.scope || '');
-    return jsonUtils.loadJsonObject(userConfigFile)
+    return jsonUtils.loadJsonObject(values.USER_CONFIG_FILE)
       .catch((err) => {
         if (err.code === 'ENOENT') {
           // missing file = not authenticated, which we handle further down
@@ -36,8 +35,7 @@ module.exports = {
 
   getAuthentications (options) {
     options = options || {};
-    const userConfigFile = values.userConfigFile(options.userConfigDir);
-    return jsonUtils.loadJsonObject(userConfigFile)
+    return jsonUtils.loadJsonObject(values.USER_CONFIG_FILE)
       .catch((err) => {
         if (err.code === 'ENOENT') {
           // missing file = not authenticated, which we handle further down

--- a/test/api.js
+++ b/test/api.js
@@ -1,0 +1,70 @@
+'use strict';
+
+// foreign modules
+
+const mockery = require('mockery');
+const pify = require('pify');
+const temp = pify(require('temp').track());
+const test = require('ava');
+
+// local modules
+
+const api = require('../lib/api');
+const auth = require('../lib/auth');
+const pkg = require('../package.json');
+
+// this module
+
+let reqFn;
+
+test.before(() => {
+  mockery.enable();
+  mockery.registerAllowables([ 'empower-core' ]);
+  mockery.registerMock('request', (url, cb) => reqFn(url, cb));
+});
+test.after(() => mockery.disable());
+
+test.beforeEach((t) => {
+  return temp.mkdir(pkg.name.replace(/\//g, '-') + '-')
+    .then((dirPath) => {
+      t.context.tempDir = dirPath;
+    })
+    .then(() => {
+      return auth.login({
+        credential: 'abcdef',
+        scope: 'https://example.com/space',
+        userConfigDir: t.context.tempDir
+      });
+    })
+    .then(() => {
+      return auth.login({
+        credential: 'ghijkl',
+        scope: 'https://otherexample.com/space',
+        userConfigDir: t.context.tempDir
+      });
+    });
+});
+
+test.serial('getDashboard', (t) => {
+  const ORIGIN = 'https://example.com';
+  reqFn = (url, cb) => {
+    t.is(url, `${ORIGIN}/_api/v1/dashboard`);
+    cb(null, { statusCode: 200 }, '{}');
+  };
+  return api.getDashboard({
+    auth: { origin: ORIGIN, credential: 'abcdef' }
+  });
+});
+
+test.serial('getResource', (t) => {
+  const ORIGIN = 'https://example.com';
+  reqFn = (url, cb) => {
+    t.is(url, `${ORIGIN}/_api/v1/answerspaces/123`);
+    cb(null, { statusCode: 200 }, '{}');
+  };
+  return api.getResource({
+    auth: { origin: ORIGIN, credential: 'abcdef' },
+    id: 123,
+    type: 'answerspaces'
+  });
+});

--- a/test/api.js
+++ b/test/api.js
@@ -31,16 +31,12 @@ test.beforeEach((t) => {
       t.context.tempDir = dirPath;
     })
     .then(() => {
-      return auth.login({
-        credential: 'abcdef',
-        scope: 'https://example.com/space'
-      });
+      process.env.BMP_SCOPE = 'https://example.com/space';
+      return auth.login({ credential: 'abcdef' });
     })
     .then(() => {
-      return auth.login({
-        credential: 'ghijkl',
-        scope: 'https://otherexample.com/space'
-      });
+      process.env.BMP_SCOPE = 'https://otherexample.com/space';
+      return auth.login({ credential: 'ghijkl' });
     });
 });
 

--- a/test/api.js
+++ b/test/api.js
@@ -33,10 +33,6 @@ test.beforeEach((t) => {
     .then(() => {
       process.env.BMP_SCOPE = 'https://example.com/space';
       return auth.login({ credential: 'abcdef' });
-    })
-    .then(() => {
-      process.env.BMP_SCOPE = 'https://otherexample.com/space';
-      return auth.login({ credential: 'ghijkl' });
     });
 });
 
@@ -46,9 +42,7 @@ test.serial('getDashboard', (t) => {
     t.is(url, `${ORIGIN}/_api/v1/dashboard`);
     cb(null, { statusCode: 200 }, '{}');
   };
-  return api.getDashboard({
-    auth: { origin: ORIGIN, credential: 'abcdef' }
-  });
+  return api.getDashboard();
 });
 
 test.serial('getResource', (t) => {
@@ -58,7 +52,6 @@ test.serial('getResource', (t) => {
     cb(null, { statusCode: 200 }, '{}');
   };
   return api.getResource({
-    auth: { origin: ORIGIN, credential: 'abcdef' },
     id: 123,
     type: 'answerspaces'
   });

--- a/test/api.js
+++ b/test/api.js
@@ -27,20 +27,19 @@ test.after(() => mockery.disable());
 test.beforeEach((t) => {
   return temp.mkdir(pkg.name.replace(/\//g, '-') + '-')
     .then((dirPath) => {
+      process.env.BMP_USER_CONFIG_DIR = dirPath;
       t.context.tempDir = dirPath;
     })
     .then(() => {
       return auth.login({
         credential: 'abcdef',
-        scope: 'https://example.com/space',
-        userConfigDir: t.context.tempDir
+        scope: 'https://example.com/space'
       });
     })
     .then(() => {
       return auth.login({
         credential: 'ghijkl',
-        scope: 'https://otherexample.com/space',
-        userConfigDir: t.context.tempDir
+        scope: 'https://otherexample.com/space'
       });
     });
 });

--- a/test/api.js
+++ b/test/api.js
@@ -20,7 +20,7 @@ let reqFn;
 test.before(() => {
   mockery.enable();
   mockery.registerAllowables([ 'empower-core' ]);
-  mockery.registerMock('request', (url, cb) => reqFn(url, cb));
+  mockery.registerMock('request', (options, cb) => reqFn(options, cb));
 });
 test.after(() => mockery.disable());
 
@@ -38,8 +38,8 @@ test.beforeEach((t) => {
 
 test.serial('getDashboard', (t) => {
   const ORIGIN = 'https://example.com';
-  reqFn = (url, cb) => {
-    t.is(url, `${ORIGIN}/_api/v1/dashboard`);
+  reqFn = (options, cb) => {
+    t.is(options.url, `${ORIGIN}/_api/v1/dashboard`);
     cb(null, { statusCode: 200 }, '{}');
   };
   return api.getDashboard();
@@ -47,8 +47,8 @@ test.serial('getDashboard', (t) => {
 
 test.serial('getResource', (t) => {
   const ORIGIN = 'https://example.com';
-  reqFn = (url, cb) => {
-    t.is(url, `${ORIGIN}/_api/v1/answerspaces/123`);
+  reqFn = (options, cb) => {
+    t.is(options.url, `${ORIGIN}/_api/v1/answerspaces/123`);
     cb(null, { statusCode: 200 }, '{}');
   };
   return api.getResource({

--- a/test/auth.js
+++ b/test/auth.js
@@ -35,9 +35,9 @@ test.serial('login without setting scope first', (t) => {
 
 test.serial('login with scope', (t) => {
   const CONFIG_FILE = path.join(t.context.tempDir, 'blinkmrc.json');
+  process.env.BMP_SCOPE = 'https://example.com/space';
   return auth.login({
-    credential: 'abcdef',
-    scope: 'https://example.com/space'
+    credential: 'abcdef'
   })
     .then(() => loadJson(CONFIG_FILE))
     .then((cfg) => {
@@ -47,9 +47,9 @@ test.serial('login with scope', (t) => {
 
 test.serial('logout without login first', (t) => {
   const CONFIG_FILE = path.join(t.context.tempDir, 'blinkmrc.json');
+  process.env.BMP_SCOPE = 'https://example.com/space';
   return auth.logout({
-    credential: 'abcdef',
-    scope: 'https://example.com/space'
+    credential: 'abcdef'
   })
     .then(() => loadJson(CONFIG_FILE))
     .catch((err) => {
@@ -59,9 +59,9 @@ test.serial('logout without login first', (t) => {
 
 test.serial('login then logout', (t) => {
   const CONFIG_FILE = path.join(t.context.tempDir, 'blinkmrc.json');
+  process.env.BMP_SCOPE = 'https://example.com/space';
   const options = {
-    credential: 'abcdef',
-    scope: 'https://example.com/space'
+    credential: 'abcdef'
   };
   return auth.login(options)
     .then(() => auth.logout(options))

--- a/test/auth.js
+++ b/test/auth.js
@@ -2,6 +2,7 @@
 
 // Node.js built-ins
 
+const fs = require('fs');
 const path = require('path');
 
 // foreign modules
@@ -18,7 +19,10 @@ const pkg = require('../package.json');
 
 // this module
 
+const fsp = pify(fs);
+
 test.beforeEach((t) => {
+  process.env.BMP_SCOPE = 'https://example.com/space';
   return temp.mkdir(pkg.name.replace(/\//g, '-') + '-')
     .then((dirPath) => {
       process.env.BMP_USER_CONFIG_DIR = dirPath;
@@ -27,6 +31,7 @@ test.beforeEach((t) => {
 });
 
 test.serial('login without setting scope first', (t) => {
+  process.env.BMP_SCOPE = null;
   return auth.login({
     credential: 'abcdef'
   })
@@ -35,7 +40,6 @@ test.serial('login without setting scope first', (t) => {
 
 test.serial('login with scope', (t) => {
   const CONFIG_FILE = path.join(t.context.tempDir, 'blinkmrc.json');
-  process.env.BMP_SCOPE = 'https://example.com/space';
   return auth.login({
     credential: 'abcdef'
   })
@@ -47,7 +51,6 @@ test.serial('login with scope', (t) => {
 
 test.serial('logout without login first', (t) => {
   const CONFIG_FILE = path.join(t.context.tempDir, 'blinkmrc.json');
-  process.env.BMP_SCOPE = 'https://example.com/space';
   return auth.logout({
     credential: 'abcdef'
   })
@@ -59,14 +62,60 @@ test.serial('logout without login first', (t) => {
 
 test.serial('login then logout', (t) => {
   const CONFIG_FILE = path.join(t.context.tempDir, 'blinkmrc.json');
-  process.env.BMP_SCOPE = 'https://example.com/space';
-  const options = {
+  return auth.login({
     credential: 'abcdef'
-  };
-  return auth.login(options)
-    .then(() => auth.logout(options))
+  })
+    .then(() => auth.logout())
     .then(() => loadJson(CONFIG_FILE))
     .then((cfg) => {
       t.ok(!cfg.bmp['https://example.com'].credential);
+    });
+});
+
+test.serial('read, after login', (t) => {
+  return auth.login({ credential: 'abcdef' })
+    .then(() => auth.read())
+    .then((a) => t.same(a, { origin: 'https://example.com', credential: 'abcdef' }));
+});
+
+test.serial('read, after login and logout', (t) => {
+  return auth.login({ credential: 'abcdef' })
+    .then(() => auth.logout())
+    .then(() => auth.read())
+    .then(() => t.fail('resolved'))
+    .catch((err) => t.ok(err));
+});
+
+test.serial('read, no blinkmrc.json file', (t) => {
+  return fsp.unlink(path.join(t.context.tempDir, 'blinkmrc.json'))
+    .then(() => auth.read({
+      scope: 'https://example.com/space',
+      userConfigDir: t.context.tempDir
+    }))
+    .catch((err) => t.ok(err));
+});
+
+test.serial('read, corrupt blinkmrc.json file', (t) => {
+  return fsp.appendFile(path.join(t.context.tempDir, 'blinkmrc.json'), 'abc')
+    .then(() => auth.read({
+      scope: 'https://example.com/space',
+      userConfigDir: t.context.tempDir
+    }))
+    .catch((err) => t.ok(err));
+});
+
+test.serial('readAll', (t) => {
+  process.env.BMP_SCOPE = 'https://example.com/space';
+  return auth.login({ credential: 'abcdef' })
+    .then(() => {
+      process.env.BMP_SCOPE = 'https://otherexample.com/space';
+      return auth.login({ credential: 'ghijkl' });
+    })
+    .then(() => auth.readAll())
+    .then((auths) => {
+      t.same(auths, [
+        { origin: 'https://example.com', credential: 'abcdef' },
+        { origin: 'https://otherexample.com', credential: 'ghijkl' }
+      ]);
     });
 });

--- a/test/auth.js
+++ b/test/auth.js
@@ -21,24 +21,23 @@ const pkg = require('../package.json');
 test.beforeEach((t) => {
   return temp.mkdir(pkg.name.replace(/\//g, '-') + '-')
     .then((dirPath) => {
+      process.env.BMP_USER_CONFIG_DIR = dirPath;
       t.context.tempDir = dirPath;
     });
 });
 
-test('login without setting scope first', (t) => {
+test.serial('login without setting scope first', (t) => {
   return auth.login({
-    credential: 'abcdef',
-    userConfigDir: t.context.tempDir
+    credential: 'abcdef'
   })
     .catch((err) => { t.ok(err); });
 });
 
-test('login with scope', (t) => {
+test.serial('login with scope', (t) => {
   const CONFIG_FILE = path.join(t.context.tempDir, 'blinkmrc.json');
   return auth.login({
     credential: 'abcdef',
-    scope: 'https://example.com/space',
-    userConfigDir: t.context.tempDir
+    scope: 'https://example.com/space'
   })
     .then(() => loadJson(CONFIG_FILE))
     .then((cfg) => {
@@ -46,12 +45,11 @@ test('login with scope', (t) => {
     });
 });
 
-test('logout without login first', (t) => {
+test.serial('logout without login first', (t) => {
   const CONFIG_FILE = path.join(t.context.tempDir, 'blinkmrc.json');
   return auth.logout({
     credential: 'abcdef',
-    scope: 'https://example.com/space',
-    userConfigDir: t.context.tempDir
+    scope: 'https://example.com/space'
   })
     .then(() => loadJson(CONFIG_FILE))
     .catch((err) => {
@@ -59,12 +57,11 @@ test('logout without login first', (t) => {
     });
 });
 
-test('login then logout', (t) => {
+test.serial('login then logout', (t) => {
   const CONFIG_FILE = path.join(t.context.tempDir, 'blinkmrc.json');
   const options = {
     credential: 'abcdef',
-    scope: 'https://example.com/space',
-    userConfigDir: t.context.tempDir
+    scope: 'https://example.com/space'
   };
   return auth.login(options)
     .then(() => auth.logout(options))

--- a/test/deploy.js
+++ b/test/deploy.js
@@ -1,0 +1,86 @@
+'use strict';
+
+// Node.js built-ins
+
+const path = require('path');
+
+// foreign modules
+
+const mkdirp = require('mkdirp');
+const mockery = require('mockery');
+const pify = require('pify');
+const temp = pify(require('temp').track());
+const test = require('ava');
+const writeJson = require('write-json-file');
+
+// local modules
+
+const auth = require('../lib/auth');
+const deploy = require('../lib/deploy');
+const pkg = require('../package.json');
+
+// this module
+
+let reqFn;
+
+test.before(() => {
+  mockery.enable();
+  mockery.registerAllowables([ 'empower-core' ]);
+  mockery.registerMock('request', (options, cb) => reqFn(options, cb));
+});
+test.after(() => mockery.disable());
+
+test.beforeEach((t) => {
+  return temp.mkdir(pkg.name.replace(/\//g, '-') + '-')
+    .then((dirPath) => {
+      process.env.BMP_USER_CONFIG_DIR = dirPath;
+      process.env.BMP_WORKING_DIR = dirPath;
+      t.context.tempDir = dirPath;
+    })
+    .then(() => {
+      process.env.BMP_SCOPE = 'https://example.com/space';
+      return auth.login({ credential: 'abcdef' });
+    });
+});
+
+test.serial('deployAll', (t) => {
+  const ORIGIN = 'https://example.com';
+  reqFn = (options, cb) => {
+    switch (options.url) {
+      case `${ORIGIN}/_api/v1/answerspaces/123`:
+        cb(null, { statusCode: 200 }, `{}`);
+        break;
+
+      case `${ORIGIN}/_api/v1/interactions/456`:
+        cb(null, { statusCode: 200 }, `{}`);
+        break;
+
+      default:
+        cb(new Error('unexpected fetch'));
+    }
+  };
+  return writeJson(path.join(t.context.tempDir, 'answerSpace.json'), {
+    id: '123'
+  })
+    .then(() => mkdirp(path.join(t.context.tempDir, 'interactions', 'test')))
+    .then(() => writeJson(path.join(t.context.tempDir, 'interactions', 'test', 'test.json'), {
+      id: '456'
+    }))
+    .then(() => deploy.deployAll());
+});
+
+test.serial('deployAll no interactions', (t) => {
+  const ORIGIN = 'https://example.com';
+  reqFn = (options, cb) => {
+    switch (options.url) {
+      case `${ORIGIN}/_api/v1/answerspaces/123`:
+        cb(null, { statusCode: 200 }, `{}`);
+        break;
+
+      default:
+        cb(new Error('unexpected fetch'));
+    }
+  };
+  return writeJson(path.join(t.context.tempDir, 'answerSpace.json'), { id: '123' })
+    .then(() => deploy.deployAll());
+});

--- a/test/pull.js
+++ b/test/pull.js
@@ -34,6 +34,7 @@ test.beforeEach((t) => {
   return temp.mkdir(pkg.name.replace(/\//g, '-') + '-')
     .then((dirPath) => {
       process.env.BMP_USER_CONFIG_DIR = dirPath;
+      process.env.BMP_WORKING_DIR = dirPath;
       t.context.tempDir = dirPath;
     })
     .then(() => {
@@ -77,8 +78,7 @@ test.serial('pullAnswerSpace', (t) => {
     }
   };
   return pull.pullAnswerSpace({
-    auth: { origin: ORIGIN },
-    cwd: t.context.tempDir
+    auth: { origin: ORIGIN }
   })
     .then(() => fsp.access(path.join(t.context.tempDir, 'answerSpace.json')), fs.R_OK)
     .then(() => fsp.access(path.join(t.context.tempDir, 'interactions')), fs.R_OK | fs.X_OK)

--- a/test/pull.js
+++ b/test/pull.js
@@ -33,25 +33,24 @@ test.after(() => mockery.disable());
 test.beforeEach((t) => {
   return temp.mkdir(pkg.name.replace(/\//g, '-') + '-')
     .then((dirPath) => {
+      process.env.BMP_USER_CONFIG_DIR = dirPath;
       t.context.tempDir = dirPath;
     })
     .then(() => {
       return auth.login({
         credential: 'abcdef',
-        scope: 'https://example.com/space',
-        userConfigDir: t.context.tempDir
+        scope: 'https://example.com/space'
       });
     })
     .then(() => {
       return auth.login({
         credential: 'ghijkl',
-        scope: 'https://otherexample.com/space',
-        userConfigDir: t.context.tempDir
+        scope: 'https://otherexample.com/space'
       });
     });
 });
 
-test('pullAnswerSpace', (t) => {
+test.serial('pullAnswerSpace', (t) => {
   const ORIGIN = 'https://example.com';
   reqFn = (url, cb) => {
     switch (url) {

--- a/test/pull.js
+++ b/test/pull.js
@@ -38,16 +38,12 @@ test.beforeEach((t) => {
       t.context.tempDir = dirPath;
     })
     .then(() => {
-      return auth.login({
-        credential: 'abcdef',
-        scope: 'https://example.com/space'
-      });
+      process.env.BMP_SCOPE = 'https://example.com/space';
+      return auth.login({ credential: 'abcdef' });
     })
     .then(() => {
-      return auth.login({
-        credential: 'ghijkl',
-        scope: 'https://otherexample.com/space'
-      });
+      process.env.BMP_SCOPE = 'https://otherexample.com/space';
+      return auth.login({ credential: 'ghijkl' });
     });
 });
 

--- a/test/pull.js
+++ b/test/pull.js
@@ -40,10 +40,6 @@ test.beforeEach((t) => {
     .then(() => {
       process.env.BMP_SCOPE = 'https://example.com/space';
       return auth.login({ credential: 'abcdef' });
-    })
-    .then(() => {
-      process.env.BMP_SCOPE = 'https://otherexample.com/space';
-      return auth.login({ credential: 'ghijkl' });
     });
 });
 
@@ -73,9 +69,7 @@ test.serial('pullAnswerSpace', (t) => {
         cb(new Error('unexpected fetch'));
     }
   };
-  return pull.pullAnswerSpace({
-    auth: { origin: ORIGIN }
-  })
+  return pull.pullAnswerSpace()
     .then(() => fsp.access(path.join(t.context.tempDir, 'answerSpace.json')), fs.R_OK)
     .then(() => fsp.access(path.join(t.context.tempDir, 'interactions')), fs.R_OK | fs.X_OK)
     .then(() => fsp.access(path.join(t.context.tempDir, 'interactions', 'test')), fs.R_OK | fs.X_OK)

--- a/test/pull.js
+++ b/test/pull.js
@@ -26,7 +26,7 @@ let reqFn;
 test.before(() => {
   mockery.enable();
   mockery.registerAllowables([ 'empower-core' ]);
-  mockery.registerMock('request', (url, cb) => reqFn(url, cb));
+  mockery.registerMock('request', (options, cb) => reqFn(options, cb));
 });
 test.after(() => mockery.disable());
 
@@ -45,8 +45,8 @@ test.beforeEach((t) => {
 
 test.serial('pullAnswerSpace', (t) => {
   const ORIGIN = 'https://example.com';
-  reqFn = (url, cb) => {
-    switch (url) {
+  reqFn = (options, cb) => {
+    switch (options.url) {
       case `${ORIGIN}/_api/v1/dashboard`:
         cb(null, { statusCode: 200 }, '{ "answerSpace": { "id": "123" } }');
         break;

--- a/test/pull.js
+++ b/test/pull.js
@@ -51,30 +51,6 @@ test.beforeEach((t) => {
     });
 });
 
-test.serial('getDashboard', (t) => {
-  const ORIGIN = 'https://example.com';
-  reqFn = (url, cb) => {
-    t.is(url, `${ORIGIN}/_api/v1/dashboard`);
-    cb(null, { statusCode: 200 }, '{}');
-  };
-  return pull.getDashboard({
-    auth: { origin: ORIGIN, credential: 'abcdef' }
-  });
-});
-
-test.serial('getJson', (t) => {
-  const ORIGIN = 'https://example.com';
-  reqFn = (url, cb) => {
-    t.is(url, `${ORIGIN}/_api/v1/answerspaces/123`);
-    cb(null, { statusCode: 200 }, '{}');
-  };
-  return pull.getJson({
-    auth: { origin: ORIGIN, credential: 'abcdef' },
-    id: 123,
-    type: 'answerspaces'
-  });
-});
-
 test('pullAnswerSpace', (t) => {
   const ORIGIN = 'https://example.com';
   reqFn = (url, cb) => {

--- a/test/resource.js
+++ b/test/resource.js
@@ -1,0 +1,47 @@
+'use strict';
+
+// foreign modules
+
+const test = require('ava');
+
+// local modules
+
+const resource = require('../lib/resource');
+
+// this module
+
+test('fixAnswerSpace', (t) => {
+  const input = {
+    created_time: '',
+    modified_time: '',
+    links: {},
+    sitemap: ''
+  };
+  const output = resource.fixAnswerSpace(input);
+  t.ok(input === output, 'mutates input object');
+  t.same(output, {});
+});
+
+test('fixInteraction', (t) => {
+  const input = {
+    created_time: '',
+    modified_time: '',
+    links: {},
+    order: 1
+  };
+  const output = resource.fixInteraction(input);
+  t.ok(input === output, 'mutates input object');
+  t.same(output, { order: 1 });
+});
+
+test('fixInteraction with null order', (t) => {
+  const input = {
+    created_time: '',
+    modified_time: '',
+    links: {},
+    order: null
+  };
+  const output = resource.fixInteraction(input);
+  t.ok(input === output, 'mutates input object');
+  t.same(output, {});
+});

--- a/test/scope.js
+++ b/test/scope.js
@@ -20,6 +20,7 @@ const pkg = require('../package.json');
 test.beforeEach((t) => {
   return temp.mkdir(pkg.name.replace(/\//g, '-') + '-')
     .then((dirPath) => {
+      process.env.BMP_USER_CONFIG_DIR = dirPath;
       t.context.tempDir = dirPath;
     });
 });
@@ -37,7 +38,7 @@ test.serial('read missing .blinkmrc.json', (t) => {
     });
 });
 
-test('read empty .blinkmrc.json', (t) => {
+test.serial('read empty .blinkmrc.json', (t) => {
   const cwd = path.join(__dirname, 'fixtures', 'scope', 'empty');
   return lib.read({ cwd })
     .then(() => {
@@ -49,7 +50,7 @@ test('read empty .blinkmrc.json', (t) => {
     });
 });
 
-test('read .blinkmrc.json in same directory', (t) => {
+test.serial('read .blinkmrc.json in same directory', (t) => {
   const cwd = path.join(__dirname, 'fixtures', 'scope');
   return lib.read({ cwd })
     .then((scope) => {
@@ -57,7 +58,7 @@ test('read .blinkmrc.json in same directory', (t) => {
     });
 });
 
-test('read .blinkmrc.json in parent directory', (t) => {
+test.serial('read .blinkmrc.json in parent directory', (t) => {
   const cwd = path.join(__dirname, 'fixtures', 'scope', 'sub');
   return lib.read({ cwd })
     .then((scope) => {
@@ -65,7 +66,7 @@ test('read .blinkmrc.json in parent directory', (t) => {
     });
 });
 
-test('write invalid scope URL to .blinkmrc.json', (t) => {
+test.serial('write invalid scope URL to .blinkmrc.json', (t) => {
   const cwd = t.context.tempDir;
   return lib.write({ cwd, scope: 'abc' })
     .then(() => {

--- a/test/scope.js
+++ b/test/scope.js
@@ -21,13 +21,13 @@ test.beforeEach((t) => {
   return temp.mkdir(pkg.name.replace(/\//g, '-') + '-')
     .then((dirPath) => {
       process.env.BMP_USER_CONFIG_DIR = dirPath;
+      process.env.BMP_WORKING_DIR = dirPath;
       t.context.tempDir = dirPath;
     });
 });
 
 test.serial('read missing .blinkmrc.json', (t) => {
-  const cwd = t.context.tempDir;
-  return lib.read({ cwd })
+  return lib.read()
     .then((result) => {
       console.log(result);
       t.fail();
@@ -39,8 +39,8 @@ test.serial('read missing .blinkmrc.json', (t) => {
 });
 
 test.serial('read empty .blinkmrc.json', (t) => {
-  const cwd = path.join(__dirname, 'fixtures', 'scope', 'empty');
-  return lib.read({ cwd })
+  process.env.BMP_WORKING_DIR = path.join(__dirname, 'fixtures', 'scope', 'empty');
+  return lib.read()
     .then(() => {
       t.fail();
     })
@@ -51,24 +51,23 @@ test.serial('read empty .blinkmrc.json', (t) => {
 });
 
 test.serial('read .blinkmrc.json in same directory', (t) => {
-  const cwd = path.join(__dirname, 'fixtures', 'scope');
-  return lib.read({ cwd })
+  process.env.BMP_WORKING_DIR = path.join(__dirname, 'fixtures', 'scope');
+  return lib.read()
     .then((scope) => {
       t.is(scope, 'https://example.com/space');
     });
 });
 
 test.serial('read .blinkmrc.json in parent directory', (t) => {
-  const cwd = path.join(__dirname, 'fixtures', 'scope', 'sub');
-  return lib.read({ cwd })
+  process.env.BMP_WORKING_DIR = path.join(__dirname, 'fixtures', 'scope', 'sub');
+  return lib.read()
     .then((scope) => {
       t.is(scope, 'https://example.com/space');
     });
 });
 
 test.serial('write invalid scope URL to .blinkmrc.json', (t) => {
-  const cwd = t.context.tempDir;
-  return lib.write({ cwd, scope: 'abc' })
+  return lib.write({ scope: 'abc' })
     .then(() => {
       t.fail();
     })
@@ -79,20 +78,29 @@ test.serial('write invalid scope URL to .blinkmrc.json', (t) => {
 });
 
 test.serial('write to .blinkmrc.json in same directory', (t) => {
-  const cwd = t.context.tempDir;
-  return lib.write({ cwd, scope: 'https://example.com/space' })
-    .then(() => lib.read({ cwd }))
+  return lib.write({ scope: 'https://example.com/space' })
+    .then(() => lib.read())
     .then((scope) => {
       t.is(scope, 'https://example.com/space');
     });
 });
 
 test.serial('update to .blinkmrc.json in parent directory', (t) => {
-  const cwd = path.join(t.context.tempDir, 'test');
-  return lib.write({ cwd: t.context.tempDir, scope: 'https://example.com/space' })
-    .then(() => lib.write({ cwd, scope: 'https://example.com/abcdef' }))
-    .then(() => lib.read({ cwd: t.context.tempDir }))
-    .then((scope) => {
-      t.is(scope, 'https://example.com/abcdef');
-    });
+  // write from parent directory
+  process.env.BMP_WORKING_DIR = t.context.tempDir;
+  return lib.write({ scope: 'https://example.com/space' })
+    .then(() => {
+      // write from sub-directory
+      process.env.BMP_WORKING_DIR = path.join(t.context.tempDir, 'test');
+      return lib.write({ scope: 'https://example.com/abcdef' });
+    })
+    // read from sub-directory
+    .then(() => lib.read())
+    .then((scope) => t.is(scope, 'https://example.com/abcdef'))
+    // read from parent directory
+    .then(() => {
+      process.env.BMP_WORKING_DIR = t.context.tempDir;
+      return lib.read();
+    })
+    .then((scope) => t.is(scope, 'https://example.com/abcdef'));
 });

--- a/test/scope.js
+++ b/test/scope.js
@@ -34,7 +34,6 @@ test.serial('read missing .blinkmrc.json', (t) => {
     })
     .catch((err) => {
       t.ok(err);
-      return Promise.resolve();
     });
 });
 
@@ -46,7 +45,6 @@ test.serial('read empty .blinkmrc.json', (t) => {
     })
     .catch((err) => {
       t.ok(err);
-      return Promise.resolve();
     });
 });
 
@@ -73,7 +71,6 @@ test.serial('write invalid scope URL to .blinkmrc.json', (t) => {
     })
     .catch((err) => {
       t.ok(err);
-      return Promise.resolve();
     });
 });
 

--- a/test/whoami.js
+++ b/test/whoami.js
@@ -108,8 +108,7 @@ test('lookupUser, 200', (t) => {
     cb(null, { statusCode: 200 }, '{}');
   };
   return whoami.lookupUser({
-    auth: { origin: ORIGIN, credential: 'abcdef' },
-    reqFn
+    auth: { origin: ORIGIN, credential: 'abcdef' }
   });
 });
 
@@ -120,20 +119,7 @@ test('lookupUser for HTTP scope, 200', (t) => {
     cb(null, { statusCode: 200 }, '{}');
   };
   return whoami.lookupUser({
-    auth: { origin: ORIGIN, credential: 'abcdef' },
-    reqFn
-  });
-});
-
-test('lookupUser for HTTP scope, 200', (t) => {
-  const ORIGIN = 'http://example.com';
-  const reqFn = (url, cb) => {
-    t.is(url, `https://example.com/_api/v1/dashboard`);
-    cb(null, { statusCode: 200 }, '{}');
-  };
-  return whoami.lookupUser({
-    auth: { origin: ORIGIN, credential: 'abcdef' },
-    reqFn
+    auth: { origin: ORIGIN, credential: 'abcdef' }
   });
 });
 
@@ -144,8 +130,7 @@ test('lookupUser, error', (t) => {
     cb(new Error('blah'));
   };
   return whoami.lookupUser({
-    auth: { origin: ORIGIN, credential: 'abcdef' },
-    reqFn
+    auth: { origin: ORIGIN, credential: 'abcdef' }
   })
     .catch((err) => {
       t.is(err.message, 'blah');
@@ -159,8 +144,7 @@ test('lookupUser, 403', (t) => {
     cb(null, { statusCode: 403 });
   };
   return whoami.lookupUser({
-    auth: { origin: ORIGIN, credential: 'abcdef' },
-    reqFn
+    auth: { origin: ORIGIN, credential: 'abcdef' }
   })
     .catch((err) => {
       t.is(err.message, '403');

--- a/test/whoami.js
+++ b/test/whoami.js
@@ -125,6 +125,18 @@ test('lookupUser for HTTP scope, 200', (t) => {
   });
 });
 
+test('lookupUser for HTTP scope, 200', (t) => {
+  const ORIGIN = 'http://example.com';
+  const req = (url, cb) => {
+    t.is(url, `https://example.com/_api/v1/dashboard`);
+    cb(null, { statusCode: 200 }, '{}');
+  };
+  return whoami.lookupUser({
+    auth: { origin: ORIGIN, credential: 'abcdef' },
+    req
+  });
+});
+
 test('lookupUser, error', (t) => {
   const ORIGIN = 'https://example.com';
   reqFn = (url, cb) => {

--- a/test/whoami.js
+++ b/test/whoami.js
@@ -35,26 +35,22 @@ test.beforeEach((t) => {
   return temp.mkdir(pkg.name.replace(/\//g, '-') + '-')
     .then((dirPath) => {
       process.env.BMP_USER_CONFIG_DIR = dirPath;
+      process.env.BMP_WORKING_DIR = dirPath;
       t.context.tempDir = dirPath;
     })
     .then(() => {
-      return auth.login({
-        credential: 'abcdef',
-        scope: 'https://example.com/space'
-      });
+      process.env.BMP_SCOPE = 'https://example.com/space';
+      return auth.login({ credential: 'abcdef' });
     })
     .then(() => {
-      return auth.login({
-        credential: 'ghijkl',
-        scope: 'https://otherexample.com/space'
-      });
+      process.env.BMP_SCOPE = 'https://otherexample.com/space';
+      return auth.login({ credential: 'ghijkl' });
     });
 });
 
 test.serial('getAuthentication', (t) => {
-  return whoami.getAuthentication({
-    scope: 'https://example.com/space'
-  })
+  process.env.BMP_SCOPE = 'https://example.com/space';
+  return whoami.getAuthentication()
     .then((auth) => {
       t.same(auth, { origin: 'https://example.com', credential: 'abcdef' });
     });
@@ -79,11 +75,9 @@ test.serial('getAuthentication, corrupt blinkmrc.json file', (t) => {
 });
 
 test.serial('getAuthentication, after logging out', (t) => {
-  const options = {
-    scope: 'https://example.com/space'
-  };
-  return auth.logout(options)
-    .then(() => whoami.getAuthentication(options))
+  process.env.BMP_SCOPE = 'https://example.com/space';
+  return auth.logout()
+    .then(() => whoami.getAuthentication())
     .then(() => t.fail('resolved'))
     .catch((err) => t.ok(err));
 });

--- a/test/whoami.js
+++ b/test/whoami.js
@@ -127,13 +127,13 @@ test('lookupUser for HTTP scope, 200', (t) => {
 
 test('lookupUser for HTTP scope, 200', (t) => {
   const ORIGIN = 'http://example.com';
-  const req = (url, cb) => {
+  const reqFn = (url, cb) => {
     t.is(url, `https://example.com/_api/v1/dashboard`);
     cb(null, { statusCode: 200 }, '{}');
   };
   return whoami.lookupUser({
     auth: { origin: ORIGIN, credential: 'abcdef' },
-    req
+    reqFn
   });
 });
 

--- a/test/whoami.js
+++ b/test/whoami.js
@@ -20,7 +20,7 @@ let reqFn;
 test.before(() => {
   mockery.enable();
   mockery.registerAllowables([ 'empower-core' ]);
-  mockery.registerMock('request', (url, cb) => reqFn(url, cb));
+  mockery.registerMock('request', (options, cb) => reqFn(options, cb));
 });
 test.after(() => mockery.disable());
 
@@ -39,8 +39,8 @@ test.beforeEach((t) => {
 
 test.serial('lookupUser, 200', (t) => {
   const ORIGIN = 'https://example.com';
-  reqFn = (url, cb) => {
-    t.is(url, `${ORIGIN}/_api/v1/dashboard`);
+  reqFn = (options, cb) => {
+    t.is(options.url, `${ORIGIN}/_api/v1/dashboard`);
     cb(null, { statusCode: 200 }, '{}');
   };
   return whoami.lookupUser();
@@ -48,8 +48,8 @@ test.serial('lookupUser, 200', (t) => {
 
 test.serial('lookupUser for HTTP scope, 200', (t) => {
   process.env.BMP_SCOPE = 'http://example.com/space';
-  reqFn = (url, cb) => {
-    t.is(url, `https://example.com/_api/v1/dashboard`);
+  reqFn = (options, cb) => {
+    t.is(options.url, `https://example.com/_api/v1/dashboard`);
     cb(null, { statusCode: 200 }, '{}');
   };
   return whoami.lookupUser();
@@ -57,8 +57,8 @@ test.serial('lookupUser for HTTP scope, 200', (t) => {
 
 test.serial('lookupUser, error', (t) => {
   const ORIGIN = 'https://example.com';
-  reqFn = (url, cb) => {
-    t.is(url, `${ORIGIN}/_api/v1/dashboard`);
+  reqFn = (options, cb) => {
+    t.is(options.url, `${ORIGIN}/_api/v1/dashboard`);
     cb(new Error('blah'));
   };
   return whoami.lookupUser()
@@ -69,8 +69,8 @@ test.serial('lookupUser, error', (t) => {
 
 test.serial('lookupUser, 403', (t) => {
   const ORIGIN = 'https://example.com';
-  reqFn = (url, cb) => {
-    t.is(url, `${ORIGIN}/_api/v1/dashboard`);
+  reqFn = (options, cb) => {
+    t.is(options.url, `${ORIGIN}/_api/v1/dashboard`);
     cb(null, { statusCode: 403 });
   };
   return whoami.lookupUser()

--- a/test/whoami.js
+++ b/test/whoami.js
@@ -34,35 +34,33 @@ test.after(() => mockery.disable());
 test.beforeEach((t) => {
   return temp.mkdir(pkg.name.replace(/\//g, '-') + '-')
     .then((dirPath) => {
+      process.env.BMP_USER_CONFIG_DIR = dirPath;
       t.context.tempDir = dirPath;
     })
     .then(() => {
       return auth.login({
         credential: 'abcdef',
-        scope: 'https://example.com/space',
-        userConfigDir: t.context.tempDir
+        scope: 'https://example.com/space'
       });
     })
     .then(() => {
       return auth.login({
         credential: 'ghijkl',
-        scope: 'https://otherexample.com/space',
-        userConfigDir: t.context.tempDir
+        scope: 'https://otherexample.com/space'
       });
     });
 });
 
-test('getAuthentication', (t) => {
+test.serial('getAuthentication', (t) => {
   return whoami.getAuthentication({
-    scope: 'https://example.com/space',
-    userConfigDir: t.context.tempDir
+    scope: 'https://example.com/space'
   })
     .then((auth) => {
       t.same(auth, { origin: 'https://example.com', credential: 'abcdef' });
     });
 });
 
-test('getAuthentication, no blinkmrc.json file', (t) => {
+test.serial('getAuthentication, no blinkmrc.json file', (t) => {
   return fsp.unlink(path.join(t.context.tempDir, 'blinkmrc.json'))
     .then(() => whoami.getAuthentication({
       scope: 'https://example.com/space',
@@ -71,7 +69,7 @@ test('getAuthentication, no blinkmrc.json file', (t) => {
     .catch((err) => t.ok(err));
 });
 
-test('getAuthentication, corrupt blinkmrc.json file', (t) => {
+test.serial('getAuthentication, corrupt blinkmrc.json file', (t) => {
   return fsp.appendFile(path.join(t.context.tempDir, 'blinkmrc.json'), 'abc')
     .then(() => whoami.getAuthentication({
       scope: 'https://example.com/space',
@@ -80,10 +78,9 @@ test('getAuthentication, corrupt blinkmrc.json file', (t) => {
     .catch((err) => t.ok(err));
 });
 
-test('getAuthentication, after logging out', (t) => {
+test.serial('getAuthentication, after logging out', (t) => {
   const options = {
-    scope: 'https://example.com/space',
-    userConfigDir: t.context.tempDir
+    scope: 'https://example.com/space'
   };
   return auth.logout(options)
     .then(() => whoami.getAuthentication(options))
@@ -91,8 +88,8 @@ test('getAuthentication, after logging out', (t) => {
     .catch((err) => t.ok(err));
 });
 
-test('getAuthentications', (t) => {
-  return whoami.getAuthentications({ userConfigDir: t.context.tempDir })
+test.serial('getAuthentications', (t) => {
+  return whoami.getAuthentications({})
     .then((auths) => {
       t.same(auths, [
         { origin: 'https://example.com', credential: 'abcdef' },
@@ -101,7 +98,7 @@ test('getAuthentications', (t) => {
     });
 });
 
-test('lookupUser, 200', (t) => {
+test.serial('lookupUser, 200', (t) => {
   const ORIGIN = 'https://example.com';
   reqFn = (url, cb) => {
     t.is(url, `${ORIGIN}/_api/v1/dashboard`);
@@ -112,7 +109,7 @@ test('lookupUser, 200', (t) => {
   });
 });
 
-test('lookupUser for HTTP scope, 200', (t) => {
+test.serial('lookupUser for HTTP scope, 200', (t) => {
   const ORIGIN = 'http://example.com';
   reqFn = (url, cb) => {
     t.is(url, `https://example.com/_api/v1/dashboard`);
@@ -123,7 +120,7 @@ test('lookupUser for HTTP scope, 200', (t) => {
   });
 });
 
-test('lookupUser, error', (t) => {
+test.serial('lookupUser, error', (t) => {
   const ORIGIN = 'https://example.com';
   reqFn = (url, cb) => {
     t.is(url, `${ORIGIN}/_api/v1/dashboard`);
@@ -137,7 +134,7 @@ test('lookupUser, error', (t) => {
     });
 });
 
-test('lookupUser, 403', (t) => {
+test.serial('lookupUser, 403', (t) => {
   const ORIGIN = 'https://example.com';
   reqFn = (url, cb) => {
     t.is(url, `${ORIGIN}/_api/v1/dashboard`);

--- a/test/whoami.js
+++ b/test/whoami.js
@@ -1,10 +1,5 @@
 'use strict';
 
-// Node.js built-ins
-
-const fs = require('fs');
-const path = require('path');
-
 // foreign modules
 
 const mockery = require('mockery');
@@ -19,8 +14,6 @@ const pkg = require('../package.json');
 const whoami = require('../lib/whoami');
 
 // this module
-
-const fsp = pify(fs);
 
 let reqFn;
 
@@ -41,54 +34,6 @@ test.beforeEach((t) => {
     .then(() => {
       process.env.BMP_SCOPE = 'https://example.com/space';
       return auth.login({ credential: 'abcdef' });
-    })
-    .then(() => {
-      process.env.BMP_SCOPE = 'https://otherexample.com/space';
-      return auth.login({ credential: 'ghijkl' });
-    });
-});
-
-test.serial('getAuthentication', (t) => {
-  process.env.BMP_SCOPE = 'https://example.com/space';
-  return whoami.getAuthentication()
-    .then((auth) => {
-      t.same(auth, { origin: 'https://example.com', credential: 'abcdef' });
-    });
-});
-
-test.serial('getAuthentication, no blinkmrc.json file', (t) => {
-  return fsp.unlink(path.join(t.context.tempDir, 'blinkmrc.json'))
-    .then(() => whoami.getAuthentication({
-      scope: 'https://example.com/space',
-      userConfigDir: t.context.tempDir
-    }))
-    .catch((err) => t.ok(err));
-});
-
-test.serial('getAuthentication, corrupt blinkmrc.json file', (t) => {
-  return fsp.appendFile(path.join(t.context.tempDir, 'blinkmrc.json'), 'abc')
-    .then(() => whoami.getAuthentication({
-      scope: 'https://example.com/space',
-      userConfigDir: t.context.tempDir
-    }))
-    .catch((err) => t.ok(err));
-});
-
-test.serial('getAuthentication, after logging out', (t) => {
-  process.env.BMP_SCOPE = 'https://example.com/space';
-  return auth.logout()
-    .then(() => whoami.getAuthentication())
-    .then(() => t.fail('resolved'))
-    .catch((err) => t.ok(err));
-});
-
-test.serial('getAuthentications', (t) => {
-  return whoami.getAuthentications({})
-    .then((auths) => {
-      t.same(auths, [
-        { origin: 'https://example.com', credential: 'abcdef' },
-        { origin: 'https://otherexample.com', credential: 'ghijkl' }
-      ]);
     });
 });
 
@@ -98,20 +43,16 @@ test.serial('lookupUser, 200', (t) => {
     t.is(url, `${ORIGIN}/_api/v1/dashboard`);
     cb(null, { statusCode: 200 }, '{}');
   };
-  return whoami.lookupUser({
-    auth: { origin: ORIGIN, credential: 'abcdef' }
-  });
+  return whoami.lookupUser();
 });
 
 test.serial('lookupUser for HTTP scope, 200', (t) => {
-  const ORIGIN = 'http://example.com';
+  process.env.BMP_SCOPE = 'http://example.com/space';
   reqFn = (url, cb) => {
     t.is(url, `https://example.com/_api/v1/dashboard`);
     cb(null, { statusCode: 200 }, '{}');
   };
-  return whoami.lookupUser({
-    auth: { origin: ORIGIN, credential: 'abcdef' }
-  });
+  return whoami.lookupUser();
 });
 
 test.serial('lookupUser, error', (t) => {
@@ -120,9 +61,7 @@ test.serial('lookupUser, error', (t) => {
     t.is(url, `${ORIGIN}/_api/v1/dashboard`);
     cb(new Error('blah'));
   };
-  return whoami.lookupUser({
-    auth: { origin: ORIGIN, credential: 'abcdef' }
-  })
+  return whoami.lookupUser()
     .catch((err) => {
       t.is(err.message, 'blah');
     });
@@ -134,9 +73,7 @@ test.serial('lookupUser, 403', (t) => {
     t.is(url, `${ORIGIN}/_api/v1/dashboard`);
     cb(null, { statusCode: 403 });
   };
-  return whoami.lookupUser({
-    auth: { origin: ORIGIN, credential: 'abcdef' }
-  })
+  return whoami.lookupUser()
     .catch((err) => {
       t.is(err.message, '403');
     });


### PR DESCRIPTION
- `bm bmp deploy`

- refactor so that data such as credentials or scopes are no longer passed all the way through the call graph from top to bottom

    - simplifies testing, and limits the concerns of each individual function

- environment variables to control a few test-related but useful behaviours

- changed `getOrigin()` so that it wouldn't swallow errors

- suggest reviewing individual commits, skip any that don't start with "BC-7 # ..."