### PR TITLE
BC-8 # include "lib" directory in npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   "files": [
     "bin",
     "commands",
+    "lib",
     "index.js"
   ],
   "homepage": "https://github.com/blinkmobile/bmp-cli#readme",


### PR DESCRIPTION
- fixes a bug where the npm package doesn't actually include all the necessary files