### PR TITLE
BC-10 # display progress bars during `pull` and `deploy`

### DIFF
--- a/commands/deploy.js
+++ b/commands/deploy.js
@@ -1,11 +1,28 @@
 'use strict';
 
+// foreign modules
+
+const Gauge = require('gauge');
+
 // local modules
 
 const deploy = require('../lib/deploy');
+const progress = require('../lib/progress');
 
 // this module
 
 module.exports = function (input, flags, options) {
-  return deploy.deployAll();
+  const gauge = new Gauge();
+
+  progress.on('change', (name, completed) => gauge.show('deploy', completed));
+
+  return deploy.deployAll()
+    .then(() => {
+      progress.finish();
+      gauge.hide();
+    })
+    .catch((err) => {
+      gauge.hide();
+      throw err;
+    });
 };

--- a/commands/pull.js
+++ b/commands/pull.js
@@ -7,5 +7,5 @@ const pull = require('../lib/pull');
 // this module
 
 module.exports = function (input, flags, options) {
-  return pull.pullAnswerSpace();
+  return pull.pullAll();
 };

--- a/commands/pull.js
+++ b/commands/pull.js
@@ -1,11 +1,28 @@
 'use strict';
 
+// foreign modules
+
+const Gauge = require('gauge');
+
 // local modules
 
+const progress = require('../lib/progress');
 const pull = require('../lib/pull');
 
 // this module
 
 module.exports = function (input, flags, options) {
-  return pull.pullAll();
+  const gauge = new Gauge();
+
+  progress.on('change', (name, completed) => gauge.show('pull', completed));
+
+  return pull.pullAll()
+    .then(() => {
+      progress.finish();
+      gauge.hide();
+    })
+    .catch((err) => {
+      gauge.hide();
+      throw err;
+    });
 };

--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -16,6 +16,7 @@ const readJsonFiles = require('@blinkmobile/json-as-files').readData;
 const api = require('./api');
 const progress = require('./progress');
 const resource = require('./resource');
+const values = require('./values');
 
 // this module
 
@@ -49,7 +50,7 @@ function deployInteractions (options) {
       progress.addWork(entries.length);
       return entries;
     })
-    .then((entries) => asyncp.eachSeries(entries, async.asyncify((entry) => {
+    .then((entries) => asyncp.eachLimit(entries, values.MAX_REQUESTS, async.asyncify((entry) => {
       return deployInteraction({ cwd, entry })
         .then(() => progress.completeWork(1));
     })));

--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -14,6 +14,7 @@ const readJsonFiles = require('@blinkmobile/json-as-files').readData;
 // local modules
 
 const api = require('./api');
+const progress = require('./progress');
 const resource = require('./resource');
 
 // this module
@@ -44,8 +45,13 @@ function deployInteractions (options) {
       }
       throw err;
     })
+    .then((entries) => {
+      progress.addWork(entries.length);
+      return entries;
+    })
     .then((entries) => asyncp.eachSeries(entries, async.asyncify((entry) => {
-      return deployInteraction({ cwd, entry });
+      return deployInteraction({ cwd, entry })
+        .then(() => progress.completeWork(1));
     })));
 }
 

--- a/lib/progress.js
+++ b/lib/progress.js
@@ -1,0 +1,9 @@
+'use strict';
+
+// foreign modules
+
+const Tracker = require('are-we-there-yet').Tracker;
+
+// this module
+
+module.exports = new Tracker('app');

--- a/lib/pull.js
+++ b/lib/pull.js
@@ -6,8 +6,9 @@ const path = require('path');
 
 // foreign modules
 
+const async = require('async');
 const pify = require('pify');
-const mkdirp = pify(require('mkdirp'));
+const mkdirp = require('mkdirp');
 const writeJson = require('write-json-file');
 const writeJsonFiles = require('@blinkmobile/json-as-files').writeData;
 
@@ -19,11 +20,13 @@ const values = require('./values');
 
 // this module
 
-function pullAnswerSpace () {
-  const cwd = process.env.BMP_WORKING_DIR || process.cwd();
+const asyncp = pify(async);
+const mkdirpp = pify(mkdirp);
+
+function pullAnswerSpace (options) {
+  const cwd = options.cwd;
 
   let interactions;
-  // persist the default template with $file placeholders
   return writeJson(path.join(cwd, 'answerSpace.json'), values.defaultAnswerSpaceConfig('answerSpace'))
     .then(() => api.getDashboard())
     .then((obj) => obj.answerSpace.id)
@@ -38,30 +41,50 @@ function pullAnswerSpace () {
         data
       });
     })
-    .then(() => mkdirp(path.join(cwd, 'interactions'))
-    .then(() => Promise.all(interactions.map((id) => {
-      let name;
-      let obj;
-      return api.getResource({ id, type: 'interactions' })
-        .then((result) => {
-          obj = result.interactions;
-          name = obj.name;
+    .then(() => interactions);
+}
 
-          // persist the default template with $file placeholders
-          return writeJson(path.join(cwd, 'interactions', name, `${name}.json`), values.defaultInteractionConfig(name));
-        })
-        .then(() => {
-          const data = Object.assign({}, obj);
-          resource.fixInteraction(data);
-          // persist the real data, honoring the $file placeholders
-          return writeJsonFiles({
-            filePath: path.join(cwd, 'interactions', data.name, `${data.name}.json`),
-            data
-          });
-        });
-    }))));
+function pullInteraction (options) {
+  const cwd = options.cwd;
+
+  let name;
+  let obj;
+  return api.getResource({ id: options.id, type: 'interactions' })
+    .then((result) => {
+      obj = result.interactions;
+      name = obj.name;
+
+      // persist the default template with $file placeholders
+      return writeJson(path.join(cwd, 'interactions', name, `${name}.json`), values.defaultInteractionConfig(name));
+    })
+    .then(() => {
+      const data = Object.assign({}, obj);
+      resource.fixInteraction(data);
+      // persist the real data, honoring the $file placeholders
+      return writeJsonFiles({
+        filePath: path.join(cwd, 'interactions', data.name, `${data.name}.json`),
+        data
+      });
+    });
+}
+
+function pullInteractions (options) {
+  const cwd = options.cwd;
+  const interactions = options.interactions;
+
+  return mkdirpp(path.join(cwd, 'interactions'))
+    .then(() => asyncp.eachSeries(interactions, async.asyncify((id) => {
+      return pullInteraction({ cwd, id });
+    })));
+}
+
+function pullAll () {
+  const cwd = process.env.BMP_WORKING_DIR || process.cwd();
+
+  return pullAnswerSpace({ cwd })
+    .then((interactions) => pullInteractions({ cwd, interactions }));
 }
 
 module.exports = {
-  pullAnswerSpace
+  pullAll
 };

--- a/lib/pull.js
+++ b/lib/pull.js
@@ -75,7 +75,7 @@ function pullInteractions (options) {
 
   progress.addWork(interactions.length);
   return mkdirpp(path.join(cwd, 'interactions'))
-    .then(() => asyncp.eachSeries(interactions, async.asyncify((id) => {
+    .then(() => asyncp.eachLimit(interactions, values.MAX_REQUESTS, async.asyncify((id) => {
       return pullInteraction({ cwd, id })
         .then(() => progress.completeWork(1));
     })));

--- a/lib/pull.js
+++ b/lib/pull.js
@@ -15,6 +15,7 @@ const writeJsonFiles = require('@blinkmobile/json-as-files').writeData;
 // local modules
 
 const api = require('./api');
+const progress = require('./progress');
 const resource = require('./resource');
 const values = require('./values');
 
@@ -72,9 +73,11 @@ function pullInteractions (options) {
   const cwd = options.cwd;
   const interactions = options.interactions;
 
+  progress.addWork(interactions.length);
   return mkdirpp(path.join(cwd, 'interactions'))
     .then(() => asyncp.eachSeries(interactions, async.asyncify((id) => {
-      return pullInteraction({ cwd, id });
+      return pullInteraction({ cwd, id })
+        .then(() => progress.completeWork(1));
     })));
 }
 

--- a/lib/values.js
+++ b/lib/values.js
@@ -70,8 +70,11 @@ function defaultInteractionConfig (base) {
   return obj;
 }
 
+const MAX_REQUESTS = 5;
+
 module.exports = {
   CONFIG_FILE,
+  MAX_REQUESTS,
   defaultAnswerSpaceConfig,
   defaultConfig,
   defaultInteractionConfig

--- a/package.json
+++ b/package.json
@@ -11,9 +11,11 @@
   "dependencies": {
     "@blinkmobile/json-as-files": "1.0.0",
     "appdirectory": "0.1.0",
+    "are-we-there-yet": "1.1.1",
     "async": "1.5.2",
     "elegant-spinner": "1.0.1",
     "find-up": "1.1.0",
+    "gauge": "1.2.5",
     "load-json-file": "1.1.0",
     "log-update": "1.0.2",
     "meow": "3.7.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "mkdirp": "0.5.1",
     "pify": "2.3.0",
     "prompt": "0.2.14",
-    "request": "2.67.0",
+    "request": "2.69.0",
     "update-notifier": "0.6.0",
     "write-json-file": "1.2.0"
   },

--- a/test/pull.js
+++ b/test/pull.js
@@ -69,7 +69,7 @@ test.serial('pullAnswerSpace', (t) => {
         cb(new Error('unexpected fetch'));
     }
   };
-  return pull.pullAnswerSpace()
+  return pull.pullAll()
     .then(() => fsp.access(path.join(t.context.tempDir, 'answerSpace.json')), fs.R_OK)
     .then(() => fsp.access(path.join(t.context.tempDir, 'interactions')), fs.R_OK | fs.X_OK)
     .then(() => fsp.access(path.join(t.context.tempDir, 'interactions', 'test')), fs.R_OK | fs.X_OK)


### PR DESCRIPTION
### Added

- BC-10: display progress bars during `pull` and `deploy` (#9, @jokeyrhyme) (fixes #4)


### Code Review Notes

- skip the non-BC-10 commits, they'll be rebased out once BC-7 (#5) is merged

- when I refactored pull to match deploy's structure, I realised that pull was making requesting all interactions in parallel, whilst deploy always submitted them one at a time

    - I decided to juggle up to 5 requests at a time to compromise between possibly swamping our service and testing developers' patience

- the [progress](https://www.npmjs.com/package/progress) npm module actually has an ETA as well, but the we don't know the total number of requests we'll need in advance, so I opted for the [gauge](https://www.npmjs.com/package/gauge) module instead