### PR TITLE
BC-13 # implement `bm bmp create interaction ...`

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -14,6 +14,9 @@ const main = require('..');
 const cli = meow({
   help: main.help,
   version: true
+}, {
+  boolean: [ 'remote' ],
+  type: [ 'type' ]
 });
 
 main(cli.input, cli.flags);

--- a/commands/create.js
+++ b/commands/create.js
@@ -1,0 +1,44 @@
+'use strict';
+
+// local modules
+
+const create = require('../lib/create');
+
+// this module
+
+const INTERACTION = 'interaction';
+const RESOURCE_TYPES = [ INTERACTION ];
+const INTERACTION_MADL = 'madl';
+const DEFAULT_INTERACTION_TYPE = INTERACTION_MADL;
+const INTERACTION_TYPES = [ INTERACTION_MADL, 'message' ];
+
+module.exports = function (input, flags, options) {
+  const resourceType = input[0];
+  const name = input[1];
+
+  if (!~RESOURCE_TYPES.indexOf(resourceType)) {
+    console.error(`provide a supported resource: ${RESOURCE_TYPES.join(', ')}`);
+    process.exit(1);
+  }
+
+  let subType;
+
+  if (resourceType === INTERACTION) {
+    subType = flags.type || DEFAULT_INTERACTION_TYPE;
+    if (!~INTERACTION_TYPES.indexOf(subType)) {
+      console.error(`provide a supported "type": ${INTERACTION_TYPES.join(', ')}`);
+      process.exit(1);
+    }
+  }
+
+  if (!name) {
+    console.error('mandatory "name" not provided');
+    process.exit(1);
+  }
+
+  create.newInteraction({
+    name,
+    remote: flags.remote,
+    type: subType
+  });
+};

--- a/commands/interaction.js
+++ b/commands/interaction.js
@@ -1,6 +1,0 @@
-'use strict';
-
-module.exports = function () {
-  console.error('not implemented');
-  process.exit(1);
-};

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const updateNotifier = require('update-notifier');
 
 const commands = {
   deploy: require('./commands/deploy'),
-  interaction: require('./commands/interaction'),
+  create: require('./commands/create'),
   login: require('./commands/login'),
   logout: require('./commands/logout'),
   pull: require('./commands/pull'),
@@ -23,21 +23,27 @@ const pkg = require('./package.json');
 updateNotifier({ pkg }).notify();
 
 const help = `
-  Usage: blinkm-bmp <command>
+  Usage: blinkm bmp <command>
 
   where <command> is one of:
     ${Object.keys(commands).join(', ')}
 
-  Getting started:
-    scope         => outputs the current scope
-    scope [<url>] => sets the current URL scope
-    login         => store credentials on this machine
-    logout        => remove credentials from this machine
-    pull          => download remote configuration to local files
+  Initial settings:
+    scope           => outputs the current scope
+    scope [<url>]   => sets the current URL scope
+    login           => store credentials on this machine
+    logout          => remove credentials from this machine
 
   Getting work done:
-    whoami        => double-check your authentication details
-    deploy        => update remote configuration to match local files
+    whoami          => double-check your authentication details
+    pull            => download remote configuration to local files
+    deploy          => update remote configuration to match local files
+
+  Creating new interactions:
+    create interaction <name>
+                    => creates a new hidden+active interaction locally
+      --type=<type> => type can be "madl" (default), or "message"
+      --remote      => immediately create a remote placeholder
 `;
 
 module.exports = function (input, flags) {

--- a/lib/api.js
+++ b/lib/api.js
@@ -9,15 +9,33 @@ const httpUtils = require('./utils/http');
 
 const TYPES = [ 'answerspaces', 'interactions' ];
 
-function assertTypeAndId (options) {
-  if (!options.type || !options.id) {
-    throw new TypeError('"type" and "id" must be provided');
+function assertIdOption (options) {
+  if (!options.id) {
+    throw new TypeError('"id" must be provided');
   }
 }
 
-function assertKnownType (options) {
+function assertTypeOption (options) {
+  if (!options.type) {
+    throw new TypeError('"type" must be provided');
+  }
+}
+
+function assertKnownTypeOption (options) {
   if (!~TYPES.indexOf(options.type)) {
     throw new TypeError(`"${options.type}" is not a known type`);
+  }
+}
+
+function assertDataOption (options) {
+  if (!options.data || typeof options.data !== 'object') {
+    throw new TypeError(`"data" object is mandatory`);
+  }
+}
+
+function assertMatchingIdOption (options) {
+  if (options.id !== options.data.id) {
+    throw new TypeError('"id"s in resource and options do not match');
   }
 }
 
@@ -29,11 +47,10 @@ function getDashboard () {
     }));
 }
 
-function decorateWithOptionsAssertions (fn) {
+function decorateWithOptionsAssertions (fn, assertions) {
   return (options) => {
     options = options || {};
-    assertTypeAndId(options);
-    assertKnownType(options);
+    assertions.forEach((assert) => assert(options));
 
     return fn(options);
   };
@@ -45,19 +62,37 @@ const getResource = decorateWithOptionsAssertions((options) => {
       credential: a.credential,
       url: `${a.origin}/_api/v1/${options.type}/${options.id}`
     }));
-});
+}, [
+  assertIdOption,
+  assertTypeOption,
+  assertKnownTypeOption
+]);
 
 const putResource = decorateWithOptionsAssertions((options) => {
   const body = {};
   body[options.type] = options.data;
+  let method;
+  let urlPath;
+  if (options.id) {
+    method = 'PUT';
+    urlPath = `/_api/v1/${options.type}/${options.id}`;
+  } else {
+    method = 'POST';
+    urlPath = `/_api/v1/${options.type}`;
+  }
   return auth.read()
     .then((a) => httpUtils.sendRequest({
       body,
       credential: a.credential,
-      method: 'PUT',
-      url: `${a.origin}/_api/v1/${options.type}/${options.id}`
+      method,
+      url: `${a.origin}${urlPath}`
     }));
-});
+}, [
+  assertTypeOption,
+  assertKnownTypeOption,
+  assertDataOption,
+  assertMatchingIdOption
+]);
 
 module.exports = {
   getDashboard,

--- a/lib/create.js
+++ b/lib/create.js
@@ -1,0 +1,56 @@
+'use strict';
+
+// Node.js built-ins
+
+const fs = require('fs');
+const path = require('path');
+
+// foreign modules
+
+const mkdirp = require('mkdirp');
+const pify = require('pify');
+
+// local modules
+
+const deploy = require('./deploy');
+const resource = require('./resource');
+const promise = require('./utils/promise');
+
+// this module
+
+const fsp = pify(fs);
+const mkdirpp = pify(mkdirp);
+
+function assertUniqueInteractionName (options) {
+  const interactionPath = options.interactionPath;
+  const name = options.name;
+  return promise.reverse(fsp.access(interactionPath, fs.F_OK))
+    .catch(() => {
+      throw new Error(`interaction "${name}" already exists`);
+    });
+}
+
+function newInteraction (options) {
+  const cwd = process.env.BMP_WORKING_DIR || process.cwd();
+  const name = options.name;
+  const interactionPath = path.join(cwd, 'interactions', name);
+  const type = options.type;
+
+  return assertUniqueInteractionName({ interactionPath, name })
+    .then(() => mkdirpp(interactionPath))
+    // follow mostly the same process as in pull
+    .then(() => resource.writeInteraction({
+      cwd,
+      data: resource.newInteraction({ name, type }),
+      name
+    }))
+    .then(() => {
+      if (options.remote) {
+        return deploy.deployInteraction({ cwd, name });
+      }
+    });
+}
+
+module.exports = {
+  newInteraction
+};

--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -9,7 +9,6 @@ const path = require('path');
 
 const async = require('async');
 const pify = require('pify');
-const readJsonFiles = require('@blinkmobile/json-as-files').readData;
 
 // local modules
 
@@ -24,15 +23,12 @@ const fsp = pify(fs);
 const asyncp = pify(async);
 
 function deployAnswerSpace (options) {
-  return readJsonFiles({ filePath: path.join(options.cwd, 'answerSpace.json') })
-    .then((data) => resource.fixAnswerSpace(data))
+  return resource.readAnswerSpace(options)
     .then((data) => api.putResource({ id: data.id, type: 'answerspaces', data }));
 }
 
 function deployInteraction (options) {
-  const filePath = path.join(options.cwd, 'interactions', options.entry, `${options.entry}.json`);
-  return readJsonFiles({ filePath })
-    .then((data) => resource.fixInteraction(data))
+  return resource.readInteraction(options)
     .then((data) => api.putResource({ id: data.id, type: 'interactions', data }));
 }
 
@@ -46,12 +42,12 @@ function deployInteractions (options) {
       }
       throw err;
     })
-    .then((entries) => {
-      progress.addWork(entries.length);
-      return entries;
+    .then((names) => {
+      progress.addWork(names.length);
+      return names;
     })
-    .then((entries) => asyncp.eachLimit(entries, values.MAX_REQUESTS, async.asyncify((entry) => {
-      return deployInteraction({ cwd, entry })
+    .then((names) => asyncp.eachLimit(names, values.MAX_REQUESTS, async.asyncify((name) => {
+      return deployInteraction({ cwd, name })
         .then(() => progress.completeWork(1));
     })));
 }

--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -8,6 +8,7 @@ const path = require('path');
 // foreign modules
 
 const async = require('async');
+const memoize = require('lodash.memoize');
 const pify = require('pify');
 
 // local modules
@@ -22,14 +23,35 @@ const values = require('./values');
 const fsp = pify(fs);
 const asyncp = pify(async);
 
+const readCachedAnswerSpace = memoize(resource.readAnswerSpace);
+
 function deployAnswerSpace (options) {
-  return resource.readAnswerSpace(options)
+  return readCachedAnswerSpace(options)
     .then((data) => api.putResource({ id: data.id, type: 'answerspaces', data }));
 }
 
 function deployInteraction (options) {
-  return resource.readInteraction(options)
-    .then((data) => api.putResource({ id: data.id, type: 'interactions', data }));
+  let isNew;
+  return Promise.all([
+    readCachedAnswerSpace({ cwd: options.cwd }),
+    resource.readInteraction(options)
+  ])
+    .then((results) => {
+      const answerSpace = results[0];
+      const data = results[1];
+      isNew = !data.id;
+      data.links = { answerspaces: answerSpace.id };
+      return api.putResource({ id: data.id, type: 'interactions', data });
+    })
+    .then((result) => {
+      if (isNew) {
+        return resource.writeInteraction({
+          cwd: options.cwd,
+          data: result.interactions,
+          name: result.interactions.name
+        });
+      }
+    });
 }
 
 function deployInteractions (options) {
@@ -62,5 +84,6 @@ function deployAll () {
 }
 
 module.exports = {
-  deployAll
+  deployAll,
+  deployInteraction
 };

--- a/lib/pull.js
+++ b/lib/pull.js
@@ -28,7 +28,7 @@ function pullAnswerSpace (options) {
   const cwd = options.cwd;
 
   let interactions;
-  return writeJson(path.join(cwd, 'answerSpace.json'), values.defaultAnswerSpaceConfig('answerSpace'))
+  return writeJson(path.join(cwd, 'answerSpace.json'), resource.defaultAnswerSpace('answerSpace'))
     .then(() => api.getDashboard())
     .then((obj) => obj.answerSpace.id)
     .then((id) => api.getResource({ id, type: 'answerspaces' }))
@@ -56,7 +56,7 @@ function pullInteraction (options) {
       name = obj.name;
 
       // persist the default template with $file placeholders
-      return writeJson(path.join(cwd, 'interactions', name, `${name}.json`), values.defaultInteractionConfig(name));
+      return writeJson(path.join(cwd, 'interactions', name, `${name}.json`), resource.defaultInteraction(name));
     })
     .then(() => {
       const data = Object.assign({}, obj);

--- a/lib/pull.js
+++ b/lib/pull.js
@@ -46,25 +46,14 @@ function pullAnswerSpace (options) {
 }
 
 function pullInteraction (options) {
-  const cwd = options.cwd;
-
-  let name;
-  let obj;
   return api.getResource({ id: options.id, type: 'interactions' })
     .then((result) => {
-      obj = result.interactions;
-      name = obj.name;
+      const name = result.interactions.name;
 
-      // persist the default template with $file placeholders
-      return writeJson(path.join(cwd, 'interactions', name, `${name}.json`), resource.defaultInteraction(name));
-    })
-    .then(() => {
-      const data = Object.assign({}, obj);
-      resource.fixInteraction(data);
-      // persist the real data, honoring the $file placeholders
-      return writeJsonFiles({
-        filePath: path.join(cwd, 'interactions', data.name, `${data.name}.json`),
-        data
+      return resource.writeInteraction({
+        cwd: options.cwd,
+        data: result.interactions,
+        name
       });
     });
 }

--- a/lib/resource.js
+++ b/lib/resource.js
@@ -7,6 +7,8 @@ const path = require('path');
 // foreign modules
 
 const readJsonFiles = require('@blinkmobile/json-as-files').readData;
+const writeJson = require('write-json-file');
+const writeJsonFiles = require('@blinkmobile/json-as-files').writeData;
 
 // this module
 
@@ -78,11 +80,30 @@ function readInteraction (options) {
     .then((data) => fixInteraction(data));
 }
 
+function writeInteraction (options) {
+  const cwd = options.cwd;
+  const name = options.name;
+  const filePath = path.join(cwd, 'interactions', name, `${name}.json`);
+
+  // persist the default template with $file placeholders
+  return writeJson(filePath, defaultInteraction(name))
+    .then(() => {
+      const data = Object.assign({}, options.data);
+      fixInteraction(data);
+      // persist the real data, honoring the $file placeholders
+      return writeJsonFiles({
+        filePath,
+        data
+      });
+    });
+}
+
 module.exports = {
   defaultAnswerSpace,
   defaultInteraction,
   fixAnswerSpace,
   fixInteraction,
   readAnswerSpace,
-  readInteraction
+  readInteraction,
+  writeInteraction
 };

--- a/lib/resource.js
+++ b/lib/resource.js
@@ -1,5 +1,13 @@
 'use strict';
 
+// Node.js built-ins
+
+const path = require('path');
+
+// foreign modules
+
+const readJsonFiles = require('@blinkmobile/json-as-files').readData;
+
 // this module
 
 function defaultResource (base) {
@@ -59,9 +67,22 @@ function fixInteraction (data) {
   return data;
 }
 
+function readAnswerSpace (options) {
+  return readJsonFiles({ filePath: path.join(options.cwd, 'answerSpace.json') })
+    .then((data) => fixAnswerSpace(data));
+}
+
+function readInteraction (options) {
+  const filePath = path.join(options.cwd, 'interactions', options.name, `${options.name}.json`);
+  return readJsonFiles({ filePath })
+    .then((data) => fixInteraction(data));
+}
+
 module.exports = {
   defaultAnswerSpace,
   defaultInteraction,
   fixAnswerSpace,
-  fixInteraction
+  fixInteraction,
+  readAnswerSpace,
+  readInteraction
 };

--- a/lib/resource.js
+++ b/lib/resource.js
@@ -69,6 +69,32 @@ function fixInteraction (data) {
   return data;
 }
 
+function newInteraction (options) {
+  const name = options.name;
+  const data = {
+    config: {
+      all: {},
+      default: {
+        display: 'hide',
+        displayName: name
+      }
+    },
+    name
+  };
+  switch (options.type) {
+    case 'madl':
+      data.config.all.type = 'madl code';
+      data.config.default.madl = '?><?php\n';
+      break;
+
+    case 'message':
+      data.config.all.type = options.type;
+      data.config.default.message = '\n';
+      break;
+  }
+  return data;
+}
+
 function readAnswerSpace (options) {
   return readJsonFiles({ filePath: path.join(options.cwd, 'answerSpace.json') })
     .then((data) => fixAnswerSpace(data));
@@ -103,6 +129,7 @@ module.exports = {
   defaultInteraction,
   fixAnswerSpace,
   fixInteraction,
+  newInteraction,
   readAnswerSpace,
   readInteraction,
   writeInteraction

--- a/lib/resource.js
+++ b/lib/resource.js
@@ -1,5 +1,43 @@
 'use strict';
 
+// this module
+
+function defaultResource (base) {
+  return {
+    config: {
+      all: {},
+      default: {
+        footer: { $file: `${base}.footer.html` },
+        header: { $file: `${base}.header.html` },
+        styleSheet: { $file: `${base}.styleSheet.css` }
+      }
+    }
+  };
+}
+
+function defaultAnswerSpace (base) {
+  const obj = defaultResource(base);
+  Object.assign(obj.config.all, {
+    basicModeDisabledMessage: { $file: `${base}.basicModeDisabledMessage.html` }
+  });
+  Object.assign(obj.config.default, {
+    htmlHead: { $file: `${base}.htmlHead.html` },
+    introMessage: { $file: `${base}.introMessage.html` }
+  });
+  return obj;
+}
+
+function defaultInteraction (base) {
+  const obj = defaultResource(base);
+  Object.assign(obj.config.default, {
+    inputPrompt: { $file: `${base}.inputPrompt.html` },
+    madl: { $file: `${base}.madl.php` },
+    message: { $file: `${base}.message.txt` },
+    xsl: { $file: `${base}.xsl.xml` }
+  });
+  return obj;
+}
+
 function fixResource (data) {
   delete data.created_time;
   delete data.links;
@@ -22,6 +60,8 @@ function fixInteraction (data) {
 }
 
 module.exports = {
+  defaultAnswerSpace,
+  defaultInteraction,
   fixAnswerSpace,
   fixInteraction
 };

--- a/lib/utils/http.js
+++ b/lib/utils/http.js
@@ -49,7 +49,7 @@ function sendRequest (options) {
         reject(err);
         return;
       }
-      if (res.statusCode !== 200) {
+      if (!~[200, 201].indexOf(res.statusCode)) {
         reject(new Error(res.statusCode));
         console.error(options.url, res.statusCode, body);
         return;

--- a/lib/utils/promise.js
+++ b/lib/utils/promise.js
@@ -1,0 +1,13 @@
+'use strict';
+
+function reverse (promise) {
+  return new Promise((resolve, reject) => {
+    promise
+      .then(() => reject(new Error('resolved')))
+      .catch(() => resolve());
+  });
+}
+
+module.exports = {
+  reverse
+};

--- a/lib/values.js
+++ b/lib/values.js
@@ -34,50 +34,11 @@ const dirs = new AppDirectory({
 
 const USER_CONFIG_DIR = dirs.userConfig();
 
-function defaultConfig (base) {
-  return {
-    config: {
-      all: {},
-      default: {
-        footer: { $file: `${base}.footer.html` },
-        header: { $file: `${base}.header.html` },
-        styleSheet: { $file: `${base}.styleSheet.css` }
-      }
-    }
-  };
-}
-
-function defaultAnswerSpaceConfig (base) {
-  const obj = defaultConfig(base);
-  Object.assign(obj.config.all, {
-    basicModeDisabledMessage: { $file: `${base}.basicModeDisabledMessage.html` }
-  });
-  Object.assign(obj.config.default, {
-    htmlHead: { $file: `${base}.htmlHead.html` },
-    introMessage: { $file: `${base}.introMessage.html` }
-  });
-  return obj;
-}
-
-function defaultInteractionConfig (base) {
-  const obj = defaultConfig(base);
-  Object.assign(obj.config.default, {
-    inputPrompt: { $file: `${base}.inputPrompt.html` },
-    madl: { $file: `${base}.madl.php` },
-    message: { $file: `${base}.message.txt` },
-    xsl: { $file: `${base}.xsl.xml` }
-  });
-  return obj;
-}
-
 const MAX_REQUESTS = 5;
 
 module.exports = {
   CONFIG_FILE,
-  MAX_REQUESTS,
-  defaultAnswerSpaceConfig,
-  defaultConfig,
-  defaultInteractionConfig
+  MAX_REQUESTS
 };
 
 Object.defineProperty(module.exports, 'USER_CONFIG_DIR', {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "find-up": "1.1.0",
     "gauge": "1.2.5",
     "load-json-file": "1.1.0",
+    "lodash.memoize": "4.0.1",
     "log-update": "1.0.2",
     "meow": "3.7.0",
     "mkdirp": "0.5.1",

--- a/test/api.js
+++ b/test/api.js
@@ -39,6 +39,7 @@ test.beforeEach((t) => {
 test.serial('getDashboard', (t) => {
   const ORIGIN = 'https://example.com';
   reqFn = (options, cb) => {
+    t.is(options.method, 'GET');
     t.is(options.url, `${ORIGIN}/_api/v1/dashboard`);
     cb(null, { statusCode: 200 }, '{}');
   };
@@ -48,11 +49,39 @@ test.serial('getDashboard', (t) => {
 test.serial('getResource', (t) => {
   const ORIGIN = 'https://example.com';
   reqFn = (options, cb) => {
+    t.is(options.method, 'GET');
     t.is(options.url, `${ORIGIN}/_api/v1/answerspaces/123`);
     cb(null, { statusCode: 200 }, '{}');
   };
   return api.getResource({
     id: 123,
     type: 'answerspaces'
+  });
+});
+
+test.serial('putResource with id', (t) => {
+  const ORIGIN = 'https://example.com';
+  reqFn = (options, cb) => {
+    t.is(options.method, 'PUT');
+    t.is(options.url, `${ORIGIN}/_api/v1/interactions/123`);
+    cb(null, { statusCode: 200 }, '{}');
+  };
+  return api.putResource({
+    id: 123,
+    data: { id: 123 },
+    type: 'interactions'
+  });
+});
+
+test.serial('putResource without id', (t) => {
+  const ORIGIN = 'https://example.com';
+  reqFn = (options, cb) => {
+    t.is(options.method, 'POST');
+    t.is(options.url, `${ORIGIN}/_api/v1/interactions`);
+    cb(null, { statusCode: 200 }, '{}');
+  };
+  return api.putResource({
+    data: {},
+    type: 'interactions'
   });
 });

--- a/test/create.js
+++ b/test/create.js
@@ -1,0 +1,100 @@
+'use strict';
+
+// Node.js built-ins
+
+const path = require('path');
+
+// foreign modules
+
+const loadJson = require('load-json-file');
+const mockery = require('mockery');
+const pify = require('pify');
+const temp = pify(require('temp').track());
+const test = require('ava');
+const writeJson = require('write-json-file');
+
+// local modules
+
+const auth = require('../lib/auth');
+const create = require('../lib/create');
+const pkg = require('../package.json');
+
+// this module
+
+let reqFn;
+
+test.before(() => {
+  mockery.enable();
+  mockery.registerAllowables([ 'empower-core' ]);
+  mockery.registerMock('request', (options, cb) => reqFn(options, cb));
+});
+test.after(() => mockery.disable());
+
+test.beforeEach((t) => {
+  return temp.mkdir(pkg.name.replace(/\//g, '-') + '-')
+    .then((dirPath) => {
+      process.env.BMP_USER_CONFIG_DIR = dirPath;
+      process.env.BMP_WORKING_DIR = dirPath;
+      t.context.tempDir = dirPath;
+    })
+    .then(() => {
+      process.env.BMP_SCOPE = 'https://example.com/space';
+      return auth.login({ credential: 'abcdef' });
+    });
+});
+
+test.serial('newInteraction madl', (t) => {
+  const NAME = 'test';
+  return create.newInteraction({ name: NAME, type: 'madl' })
+    .then(() => loadJson(path.join(t.context.tempDir, 'interactions', NAME, `${NAME}.json`)))
+    .then((data) => {
+      t.notOk(data.id);
+      t.is(data.name, NAME);
+      t.is(data.config.all.type, 'madl code');
+      t.is(data.config.default.display, 'hide');
+    });
+});
+
+test.serial('newInteraction message', (t) => {
+  const NAME = 'test';
+  return create.newInteraction({ name: NAME, type: 'message' })
+    .then(() => loadJson(path.join(t.context.tempDir, 'interactions', NAME, `${NAME}.json`)))
+    .then((data) => {
+      t.notOk(data.id);
+      t.is(data.name, NAME);
+      t.is(data.config.all.type, 'message');
+      t.is(data.config.default.display, 'hide');
+    });
+});
+
+test.serial('newInteraction madl remote', (t) => {
+  const NAME = 'test';
+  const ORIGIN = 'https://example.com';
+
+  let isSubmitted = false;
+  reqFn = (options, cb) => {
+    isSubmitted = true;
+    switch (options.url) {
+      case `${ORIGIN}/_api/v1/interactions`:
+        t.notOk(options.body.interactions.id);
+        t.is(options.body.interactions.links.answerspaces, '123');
+        cb(null, { statusCode: 201 }, JSON.stringify({
+          interactions: { id: '456', name: NAME }
+        }));
+        break;
+
+      default:
+        cb(new Error('unexpected fetch'));
+    }
+  };
+  return writeJson(path.join(t.context.tempDir, 'answerSpace.json'), {
+    id: '123'
+  })
+    .then(() => create.newInteraction({ name: NAME, remote: true, type: 'madl' }))
+    .then(() => loadJson(path.join(t.context.tempDir, 'interactions', NAME, `${NAME}.json`)))
+    .then((data) => {
+      t.ok(isSubmitted);
+      t.is(data.id, '456');
+      t.is(data.name, NAME);
+    });
+});


### PR DESCRIPTION
### Added

- BC-13: able to create interactions via CLI with no actions within CMS (#10, @jokeyrhyme)

    - all interactions created this way have "display" set to "hide" to minimise visible impact to BIC end-users (avoids unfinished interactions showing up in generated lists)

    - `blinkm bmp create interaction <name>`  creates a new hidden+active interaction locally

        - `--type=<type>` where type can be "madl" (default), or "message"
        
        - `--remote` immediately create a remote placeholder


### Code Review Notes

- ignore / skip the BC-10 commits, they'll be rebased out

- it's probably easier to step through the refactoring commits one by one