### PR TITLE
BC-11 # safely `pull` to pre-existing local content

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,90 @@
 # Contributing
 
-[![js-standard-style](https://cdn.rawgit.com/feross/standard/master/badge.svg)](https://github.com/feross/standard)
+By contributing you agree to the [LICENSE](LICENSE) of this repository.
+
+
+## Issue Tracker
+
+- before submitting a new issue, please:
+
+    - check for existing related issues
+
+    - check the issue tracker for a specific upstream project that may be more appropriate
+
+    - check against supported versions of this project (i.e. the latest)
+
+- please DO NOT comment with a "+1", use the Subscribe button instead
+
+- please keep discussions on-topic, and respect the opinions of others
+
+- please report urgent issues, or issues with confidential details, via our commercial support channels
+
+
+### Security Vulnerabilities
+
+- please contact us privately to discuss security vulnerabilities as part of our [responsible disclosure](https://en.wikipedia.org/wiki/Responsible_disclosure) approach
+
+
+### Bug Reports
+
+- please report bugs in the [issue tracker](https://github.com/blinkmobile/bmp-cli/issues)
+
+- please provide detailed steps to reproduce
+
+
+### Feature Requests
+
+- please suggest new features and improvements in the [issue tracker](https://github.com/blinkmobile/bmp-cli/issues)
+
+
+### Personal Support Requests
+
+- please submit urgent requests for help via our commercial support channels
+
+- requests for help in the [issue tracker](https://github.com/blinkmobile/bmp-cli/issues) receive lower priority than commercial support requests
+
+
+## Pull Requests / Merge Requests
+
+- **IMPORTANT**: by submitting a patch, you agree to allow the project owners to license your work under our this [LICENSE](LICENSE)
+
+- provide tests for all features or bug fixes
+
+- provide documentation for all public API methods
+
+- Pull / Merge Request descriptions should include a change summary that matches the [Keep a CHANGELOG](http://keepachangelog.com/) format
+
+- this project uses the [GitHub Flow](https://guides.github.com/introduction/flow/) branching scheme, so changes should target the "master" branch
+
+- feel free to submit un-squashed commits provided tests pass for all commits
+
+
+## Code Style and Code Quality
+
+- adhere to our code style guides
+
+- [![js-semistandard-style](https://cdn.rawgit.com/flet/semistandard/master/badge.svg)](https://github.com/Flet/semistandard)
+
+- run `npm test` to ensure your changes follow our coding standards and pass our existing tests
+
+
+## Version Control
+
+- this project adheres to [Semantic Versioning](http://semver.org/)
+
+    - ideally, highlight when work would change the API surface in ways that break compatibility with existing consumers
+
+- compose meaningful version control comments: http://alistapart.com/article/the-art-of-the-commit
+
+
+## Development
+
+
+### Prerequisites
+
+__coming soon__
+
+
+### Getting Started
+
+__coming soon__

--- a/bin/index.js
+++ b/bin/index.js
@@ -15,7 +15,10 @@ const cli = meow({
   help: main.help,
   version: true
 }, {
-  boolean: [ 'remote' ],
+  boolean: [
+    'prune',
+    'remote'
+  ],
   type: [ 'type' ]
 });
 

--- a/commands/pull.js
+++ b/commands/pull.js
@@ -16,7 +16,7 @@ module.exports = function (input, flags, options) {
 
   progress.on('change', (name, completed) => gauge.show('pull', completed));
 
-  return pull.pullAll()
+  return pull.pullAll({ prune: !!flags.prune })
     .then(() => {
       progress.finish();
       gauge.hide();

--- a/commands/whoami.js
+++ b/commands/whoami.js
@@ -2,19 +2,16 @@
 
 // foreign modules
 
-const pify = require('pify');
-const async = require('async');
 const elegantSpinner = require('elegant-spinner');
 const logUpdate = require('log-update');
 
 // local modules
 
 const auth = require('../lib/auth');
+const asyncp = require('../lib/utils/asyncp');
 const whoami = require('../lib/whoami');
 
 // this module
-
-const pasync = pify(require('async'));
 
 function logAuthLookup (options) {
   const frame = elegantSpinner();
@@ -36,7 +33,7 @@ module.exports = function (input, flags, options) {
   auth.readAll()
     .then((auths) => {
       if (auths.length) {
-        return pasync.eachSeries(auths, async.asyncify(logAuthLookup));
+        return asyncp.eachSeries(auths, asyncp.asyncify(logAuthLookup));
       }
       console.log('no authentication data found');
     });

--- a/index.js
+++ b/index.js
@@ -37,6 +37,7 @@ const help = `
   Getting work done:
     whoami          => double-check your authentication details
     pull            => download remote configuration to local files
+      --prune       => delete local files that are missing from remote
     deploy          => update remote configuration to match local files
 
   Creating new interactions:

--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -7,13 +7,13 @@ const path = require('path');
 
 // foreign modules
 
-const async = require('async');
 const memoize = require('lodash.memoize');
 const pify = require('pify');
 
 // local modules
 
 const api = require('./api');
+const asyncp = require('./utils/asyncp');
 const progress = require('./progress');
 const resource = require('./resource');
 const values = require('./values');
@@ -21,7 +21,6 @@ const values = require('./values');
 // this module
 
 const fsp = pify(fs);
-const asyncp = pify(async);
 
 const readCachedAnswerSpace = memoize(resource.readAnswerSpace);
 
@@ -68,7 +67,7 @@ function deployInteractions (options) {
       progress.addWork(names.length);
       return names;
     })
-    .then((names) => asyncp.eachLimit(names, values.MAX_REQUESTS, async.asyncify((name) => {
+    .then((names) => asyncp.eachLimit(names, values.MAX_REQUESTS, asyncp.asyncify((name) => {
       return deployInteraction({ cwd, name })
         .then(() => progress.completeWork(1));
     })));

--- a/lib/pull.js
+++ b/lib/pull.js
@@ -9,8 +9,6 @@ const path = require('path');
 const async = require('async');
 const pify = require('pify');
 const mkdirp = require('mkdirp');
-const writeJson = require('write-json-file');
-const writeJsonFiles = require('@blinkmobile/json-as-files').writeData;
 
 // local modules
 
@@ -25,21 +23,15 @@ const asyncp = pify(async);
 const mkdirpp = pify(mkdirp);
 
 function pullAnswerSpace (options) {
-  const cwd = options.cwd;
-
   let interactions;
-  return writeJson(path.join(cwd, 'answerSpace.json'), resource.defaultAnswerSpace('answerSpace'))
-    .then(() => api.getDashboard())
+  return api.getDashboard()
     .then((obj) => obj.answerSpace.id)
     .then((id) => api.getResource({ id, type: 'answerspaces' }))
-    .then((obj) => {
-      const data = Object.assign({}, obj.answerspaces);
-      interactions = data.links.interactions || [];
-      resource.fixAnswerSpace(data);
-      // persist the real data, honoring the $file placeholders
-      return writeJsonFiles({
-        filePath: path.join(cwd, 'answerSpace.json'),
-        data
+    .then((result) => {
+      interactions = result.answerspaces.links.interactions || [];
+      return resource.writeAnswerSpace({
+        cwd: options.cwd,
+        data: result.answerspaces
       });
     })
     .then(() => interactions);
@@ -47,15 +39,11 @@ function pullAnswerSpace (options) {
 
 function pullInteraction (options) {
   return api.getResource({ id: options.id, type: 'interactions' })
-    .then((result) => {
-      const name = result.interactions.name;
-
-      return resource.writeInteraction({
-        cwd: options.cwd,
-        data: result.interactions,
-        name
-      });
-    });
+    .then((result) => resource.writeInteraction({
+      cwd: options.cwd,
+      data: result.interactions,
+      name: result.interactions.name
+    }));
 }
 
 function pullInteractions (options) {

--- a/lib/pull.js
+++ b/lib/pull.js
@@ -6,20 +6,19 @@ const path = require('path');
 
 // foreign modules
 
-const async = require('async');
 const pify = require('pify');
 const mkdirp = require('mkdirp');
 
 // local modules
 
 const api = require('./api');
+const asyncp = require('./utils/asyncp');
 const progress = require('./progress');
 const resource = require('./resource');
 const values = require('./values');
 
 // this module
 
-const asyncp = pify(async);
 const mkdirpp = pify(mkdirp);
 
 function pullAnswerSpace (options) {
@@ -52,7 +51,7 @@ function pullInteractions (options) {
 
   progress.addWork(interactions.length);
   return mkdirpp(path.join(cwd, 'interactions'))
-    .then(() => asyncp.eachLimit(interactions, values.MAX_REQUESTS, async.asyncify((id) => {
+    .then(() => asyncp.eachLimit(interactions, values.MAX_REQUESTS, asyncp.asyncify((id) => {
       return pullInteraction({ cwd, id })
         .then(() => progress.completeWork(1));
     })));

--- a/lib/pull.js
+++ b/lib/pull.js
@@ -21,6 +21,17 @@ const values = require('./values');
 
 const mkdirpp = pify(mkdirp);
 
+function pruneInteractions (options) {
+  const ids = options.interactions;
+  return resource.listInteractions({ cwd: options.cwd })
+    .then((interactions) => {
+      return interactions.filter((interaction) => !~ids.indexOf(interaction.id));
+    })
+    .then((interactions) => asyncp.eachSeries(interactions, asyncp.asyncify((i) => {
+      return resource.deleteInteraction({ cwd: options.cwd, name: i.name });
+    })));
+}
+
 function pullAnswerSpace (options) {
   let interactions;
   return api.getDashboard()
@@ -57,10 +68,18 @@ function pullInteractions (options) {
     })));
 }
 
-function pullAll () {
+function pullAll (options) {
+  options = options || {};
   const cwd = process.env.BMP_WORKING_DIR || process.cwd();
 
   return pullAnswerSpace({ cwd })
+    .then((interactions) => {
+      if (options.prune) {
+        return pruneInteractions({ cwd, interactions })
+          .then(() => interactions);
+      }
+      return interactions;
+    })
     .then((interactions) => pullInteractions({ cwd, interactions }));
 }
 

--- a/lib/resource.js
+++ b/lib/resource.js
@@ -13,6 +13,7 @@ const path = require('path');
 
 const pify = require('pify');
 const globp = pify(require('glob'));
+const loadJson = require('load-json-file');
 const readJsonFiles = require('@blinkmobile/json-as-files').readData;
 const rimrafp = pify(require('rimraf'));
 const writeJson = require('write-json-file');
@@ -85,6 +86,23 @@ function fixInteraction (data) {
   return data;
 }
 
+/** mutates defaults, does not mutate existing */
+function mergePlaceholders (existing, defaults) {
+  [
+    'all', 'default'
+  ].forEach((section) => {
+    const config = existing.config || {};
+    config[section] = config[section] || {};
+    Object.keys(config[section]).forEach((key) => {
+      const value = config[section][key];
+      if (value && typeof value === 'object' && value.$file) {
+        defaults.config[section][key] = value;
+      }
+    });
+  });
+  return defaults;
+}
+
 function listInteractions (options) {
   const cwd = options.cwd;
   return globp('*/*.json', {
@@ -142,9 +160,9 @@ function readInteraction (options) {
 
 function writeAnswerSpace (options) {
   const filePath = path.join(options.cwd, 'answerSpace.json');
+  const defaultPlaceholders = defaultAnswerSpace('answerSpace');
 
-  // persist the default template with $file placeholders
-  return writeJson(filePath, defaultAnswerSpace('answerSpace'))
+  return writeMergedPlaceholders(filePath, defaultPlaceholders)
     .then(() => {
       const data = Object.assign({}, options.data);
       fixAnswerSpace(data);
@@ -157,15 +175,22 @@ function writeInteraction (options) {
   const cwd = options.cwd;
   const name = options.name;
   const filePath = path.join(cwd, 'interactions', name, `${name}.json`);
+  const defaultPlaceholders = defaultInteraction(name);
 
-  // persist the default template with $file placeholders
-  return writeJson(filePath, defaultInteraction(name))
+  return writeMergedPlaceholders(filePath, defaultPlaceholders)
     .then(() => {
       const data = Object.assign({}, options.data);
       fixInteraction(data);
       // persist the real data, honoring the $file placeholders
       return writeJsonFiles({ data, filePath });
     });
+}
+
+function writeMergedPlaceholders (filePath, defaults) {
+  return loadJson(filePath)
+    .catch(() => ({})) // default to empty Object
+    .then((existing) => mergePlaceholders(existing, defaults))
+    .then((merged) => writeJson(filePath, merged));
 }
 
 module.exports = {

--- a/lib/resource.js
+++ b/lib/resource.js
@@ -106,6 +106,19 @@ function readInteraction (options) {
     .then((data) => fixInteraction(data));
 }
 
+function writeAnswerSpace (options) {
+  const filePath = path.join(options.cwd, 'answerSpace.json');
+
+  // persist the default template with $file placeholders
+  return writeJson(filePath, defaultAnswerSpace('answerSpace'))
+    .then(() => {
+      const data = Object.assign({}, options.data);
+      fixAnswerSpace(data);
+      // persist the real data, honoring the $file placeholders
+      return writeJsonFiles({ data, filePath });
+    });
+}
+
 function writeInteraction (options) {
   const cwd = options.cwd;
   const name = options.name;
@@ -117,10 +130,7 @@ function writeInteraction (options) {
       const data = Object.assign({}, options.data);
       fixInteraction(data);
       // persist the real data, honoring the $file placeholders
-      return writeJsonFiles({
-        filePath,
-        data
-      });
+      return writeJsonFiles({ data, filePath });
     });
 }
 
@@ -132,5 +142,6 @@ module.exports = {
   newInteraction,
   readAnswerSpace,
   readInteraction,
+  writeAnswerSpace,
   writeInteraction
 };

--- a/lib/resource.js
+++ b/lib/resource.js
@@ -194,8 +194,6 @@ function writeMergedPlaceholders (filePath, defaults) {
 }
 
 module.exports = {
-  defaultAnswerSpace,
-  defaultInteraction,
   deleteInteraction,
   fixAnswerSpace,
   fixInteraction,

--- a/lib/resource.js
+++ b/lib/resource.js
@@ -1,14 +1,26 @@
 'use strict';
 
+/**
+this module provides functions for reading and writing local files,
+as well as functions for preparing data that is about to be written
+*/
+
 // Node.js built-ins
 
 const path = require('path');
 
 // foreign modules
 
+const pify = require('pify');
+const globp = pify(require('glob'));
 const readJsonFiles = require('@blinkmobile/json-as-files').readData;
+const rimrafp = pify(require('rimraf'));
 const writeJson = require('write-json-file');
 const writeJsonFiles = require('@blinkmobile/json-as-files').writeData;
+
+// local modules
+
+const asyncp = require('./utils/asyncp');
 
 // this module
 
@@ -48,6 +60,10 @@ function defaultInteraction (base) {
   return obj;
 }
 
+function deleteInteraction (options) {
+  return rimrafp(path.join(options.cwd, 'interactions', options.name));
+}
+
 function fixResource (data) {
   delete data.created_time;
   delete data.links;
@@ -67,6 +83,24 @@ function fixInteraction (data) {
     delete data.order;
   }
   return data;
+}
+
+function listInteractions (options) {
+  const cwd = options.cwd;
+  return globp('*/*.json', {
+    cwd: path.join(cwd, 'interactions')
+  })
+    .then((files) => {
+      return files
+        // keep just the results that match NAME/NAME.json pattern
+        .filter((x) => /^([^\\\s]+)\/\1\.json$/.test(x))
+        // then just give us the names
+        .map((x) => x.split('/')[0]);
+    })
+    .then((names) => asyncp.mapSeries(names, asyncp.asyncify((name) => {
+      return readInteraction({ cwd, name })
+        .then((data) => ({ id: data.id, name: data.name }));
+    })));
 }
 
 function newInteraction (options) {
@@ -137,8 +171,10 @@ function writeInteraction (options) {
 module.exports = {
   defaultAnswerSpace,
   defaultInteraction,
+  deleteInteraction,
   fixAnswerSpace,
   fixInteraction,
+  listInteractions,
   newInteraction,
   readAnswerSpace,
   readInteraction,

--- a/lib/utils/asyncp.js
+++ b/lib/utils/asyncp.js
@@ -1,0 +1,29 @@
+'use strict';
+
+/**
+this module exports a pify'ed version of async for convenience
+*/
+
+// foreign modules
+
+const async = require('async');
+const pify = require('pify');
+
+// this module
+
+module.exports = pify(async, {
+  exclude: [
+    // https://www.npmjs.com/package/async#utils
+    'apply',
+    'nextTick',
+    'memoize',
+    'unmemoize',
+    'ensureAsync',
+    'constant',
+    'asyncify',
+    'wrapSync',
+    'log',
+    'dir',
+    'noConflict'
+  ]
+});

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "elegant-spinner": "1.0.1",
     "find-up": "1.1.0",
     "gauge": "1.2.5",
+    "glob": "6.0.4",
     "load-json-file": "1.1.0",
     "lodash.memoize": "4.0.1",
     "log-update": "1.0.2",
@@ -24,6 +25,7 @@
     "pify": "2.3.0",
     "prompt": "0.2.14",
     "request": "2.69.0",
+    "rimraf": "2.5.1",
     "update-notifier": "0.6.0",
     "write-json-file": "1.2.0"
   },

--- a/test/deploy.js
+++ b/test/deploy.js
@@ -19,6 +19,11 @@ const auth = require('../lib/auth');
 const deploy = require('../lib/deploy');
 const pkg = require('../package.json');
 
+// fixtures
+
+const oneInteraction = require('./fixtures/request/one-interaction');
+const noInteractions = require('./fixtures/request/no-interactions');
+
 // this module
 
 let reqFn;
@@ -44,21 +49,7 @@ test.beforeEach((t) => {
 });
 
 test.serial('deployAll', (t) => {
-  const ORIGIN = 'https://example.com';
-  reqFn = (options, cb) => {
-    switch (options.url) {
-      case `${ORIGIN}/_api/v1/answerspaces/123`:
-        cb(null, { statusCode: 200 }, `{}`);
-        break;
-
-      case `${ORIGIN}/_api/v1/interactions/456`:
-        cb(null, { statusCode: 200 }, `{}`);
-        break;
-
-      default:
-        cb(new Error('unexpected fetch'));
-    }
-  };
+  reqFn = oneInteraction;
   return writeJson(path.join(t.context.tempDir, 'answerSpace.json'), {
     id: '123'
   })
@@ -70,17 +61,7 @@ test.serial('deployAll', (t) => {
 });
 
 test.serial('deployAll no interactions', (t) => {
-  const ORIGIN = 'https://example.com';
-  reqFn = (options, cb) => {
-    switch (options.url) {
-      case `${ORIGIN}/_api/v1/answerspaces/123`:
-        cb(null, { statusCode: 200 }, `{}`);
-        break;
-
-      default:
-        cb(new Error('unexpected fetch'));
-    }
-  };
+  reqFn = noInteractions;
   return writeJson(path.join(t.context.tempDir, 'answerSpace.json'), { id: '123' })
     .then(() => deploy.deployAll());
 });

--- a/test/fixtures/request/no-interactions.js
+++ b/test/fixtures/request/no-interactions.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const ORIGIN = 'https://example.com';
+
+module.exports = (options, cb) => {
+  switch (options.url) {
+    case `${ORIGIN}/_api/v1/answerspaces/123`:
+      cb(null, { statusCode: 200 }, `{}`);
+      break;
+
+    default:
+      cb(new Error('unexpected fetch'));
+  }
+};

--- a/test/fixtures/request/one-interaction-formerly-two.js
+++ b/test/fixtures/request/one-interaction-formerly-two.js
@@ -1,0 +1,26 @@
+'use strict';
+
+// local modules
+
+const twoInteractions = require('./two-interactions');
+
+// this module
+
+const ORIGIN = 'https://example.com';
+
+module.exports = (options, cb) => {
+  switch (options.url) {
+    case `${ORIGIN}/_api/v1/answerspaces/123`:
+      cb(null, { statusCode: 200 }, `{
+          "answerspaces": {
+            "links": {
+              "interactions": [ "789" ]
+            }
+          }
+        }`);
+      break;
+
+    default:
+      twoInteractions(options, cb);
+  }
+};

--- a/test/fixtures/request/one-interaction.js
+++ b/test/fixtures/request/one-interaction.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const ORIGIN = 'https://example.com';
+
+module.exports = (options, cb) => {
+  switch (options.url) {
+    case `${ORIGIN}/_api/v1/dashboard`:
+      cb(null, { statusCode: 200 }, '{ "answerSpace": { "id": "123" } }');
+      break;
+
+    case `${ORIGIN}/_api/v1/answerspaces/123`:
+      cb(null, { statusCode: 200 }, `{
+          "answerspaces": {
+            "links": {
+              "interactions": [ "456" ]
+            }
+          }
+        }`);
+      break;
+
+    case `${ORIGIN}/_api/v1/interactions/456`:
+      cb(null, { statusCode: 200 }, `{ "interactions": { "name": "test" } }`);
+      break;
+
+    default:
+      cb(new Error('unexpected fetch'));
+  }
+};

--- a/test/fixtures/request/two-interactions.js
+++ b/test/fixtures/request/two-interactions.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const ORIGIN = 'https://example.com';
+
+module.exports = (options, cb) => {
+  switch (options.url) {
+    case `${ORIGIN}/_api/v1/dashboard`:
+      cb(null, { statusCode: 200 }, '{ "answerSpace": { "id": "123" } }');
+      break;
+
+    case `${ORIGIN}/_api/v1/answerspaces/123`:
+      cb(null, { statusCode: 200 }, `{
+          "answerspaces": {
+            "links": {
+              "interactions": [ "456", "789" ]
+            }
+          }
+        }`);
+      break;
+
+    case `${ORIGIN}/_api/v1/interactions/456`:
+      cb(null, { statusCode: 200 }, `{ "interactions": { "name": "def" } }`);
+      break;
+
+    case `${ORIGIN}/_api/v1/interactions/789`:
+      cb(null, { statusCode: 200 }, `{ "interactions": { "name": "ghi" } }`);
+      break;
+
+    default:
+      cb(new Error('unexpected fetch'));
+  }
+};

--- a/test/fixtures/resource/custom-refs.data.json
+++ b/test/fixtures/resource/custom-refs.data.json
@@ -1,0 +1,9 @@
+{
+  "id": "123",
+  "name": "abc",
+  "config": {
+    "default": {
+      "message": "<h1>abc</h1>"
+    }
+  }
+}

--- a/test/fixtures/resource/custom-refs.json
+++ b/test/fixtures/resource/custom-refs.json
@@ -1,0 +1,9 @@
+{
+  "config": {
+    "default": {
+      "message": {
+        "$file": "abc.message.html"
+      }
+    }
+  }
+}

--- a/test/resource.js
+++ b/test/resource.js
@@ -1,14 +1,39 @@
 'use strict';
 
+// Node.js built-ins
+
+const fs = require('fs');
+const path = require('path');
+
 // foreign modules
 
+const loadJson = require('load-json-file');
+const pify = require('pify');
+const temp = pify(require('temp').track());
 const test = require('ava');
+const writeJson = require('write-json-file');
 
 // local modules
 
+const pkg = require('../package.json');
 const resource = require('../lib/resource');
 
+// fixtures
+
+const customRefs = require('./fixtures/resource/custom-refs.json');
+const customRefsData = require('./fixtures/resource/custom-refs.data.json');
+
 // this module
+
+const fsp = pify(fs);
+
+test.beforeEach((t) => {
+  return temp.mkdir(pkg.name.replace(/\//g, '-') + '-')
+    .then((dirPath) => {
+      process.env.BMP_WORKING_DIR = dirPath;
+      t.context.tempDir = dirPath;
+    });
+});
 
 test('fixAnswerSpace', (t) => {
   const input = {
@@ -44,4 +69,18 @@ test('fixInteraction with null order', (t) => {
   const output = resource.fixInteraction(input);
   t.ok(input === output, 'mutates input object');
   t.same(output, {});
+});
+
+test.serial('writeInteraction with existing custom $file references', (t) => {
+  const NAME = 'abc';
+  return writeJson(path.join(t.context.tempDir, 'interactions', NAME, `${NAME}.json`), customRefs)
+    .then(() => resource.writeInteraction({
+      cwd: t.context.tempDir,
+      data: customRefsData,
+      name: NAME
+    }))
+    .then(() => loadJson(path.join(t.context.tempDir, 'interactions', NAME, `${NAME}.json`)))
+    .then((data) => t.same(data.config.default.message, customRefs.config.default.message))
+    .then(() => fsp.readFile(path.join(t.context.tempDir, 'interactions', NAME, `${NAME}.message.html`), 'utf8'))
+    .then((message) => t.is(message, '<h1>abc</h1>'));
 });


### PR DESCRIPTION
### Added

- BC-11: `blinkm bmp pull --prune` deletes local files missing on remote (#11, @jokeyrhyme)


### Changed

- BC-11: `blinkm bmp pull` (regardless of `--prune`) preserves existing / customised "$file" references in local files (#11, @jokeyrhyme)


### Code Review Notes

- ignore / skip BC-10 and BC-13 commits, they'll be rebased out

- added more content to our CONTRIBUTING.md file

