### PR TITLE
BC-15 # implement `blinkm bmp deploy --prune`

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,25 @@ blinkm bmp --help
 bm bmp --help
 ```
 
+>  Initial settings:
+>    scope           => outputs the current scope
+>    scope [<url>]   => sets the current URL scope
+>    login           => store credentials on this machine
+>    logout          => remove credentials from this machine
+>
+>  Getting work done:
+>    whoami          => double-check your authentication details
+>    pull            => download remote configuration to local files
+>      --prune       => delete local files that are absent from remote
+>    deploy          => update remote configuration to match local files
+>      --prune       => delete remote interactions that are absent locally
+>
+>  Creating new interactions:
+>    create interaction <name>
+>                    => creates a new hidden+active interaction locally
+>      --type=<type> => type can be "madl" (default), or "message"
+>      --remote      => also create a remote placeholder
+
 We recommend that you skim our [suggested usage](docs/suggested-usage.md).
 
 

--- a/commands/deploy.js
+++ b/commands/deploy.js
@@ -16,7 +16,7 @@ module.exports = function (input, flags, options) {
 
   progress.on('change', (name, completed) => gauge.show('deploy', completed));
 
-  return deploy.deployAll()
+  return deploy.deployAll({ prune: !!flags.prune })
     .then(() => {
       progress.finish();
       gauge.hide();

--- a/index.js
+++ b/index.js
@@ -37,14 +37,15 @@ const help = `
   Getting work done:
     whoami          => double-check your authentication details
     pull            => download remote configuration to local files
-      --prune       => delete local files that are missing from remote
+      --prune       => delete local files that are absent from remote
     deploy          => update remote configuration to match local files
+      --prune       => delete remote interactions that are absent locally
 
   Creating new interactions:
     create interaction <name>
                     => creates a new hidden+active interaction locally
       --type=<type> => type can be "madl" (default), or "message"
-      --remote      => immediately create a remote placeholder
+      --remote      => also create a remote placeholder
 `;
 
 module.exports = function (input, flags) {

--- a/lib/api.js
+++ b/lib/api.js
@@ -56,6 +56,19 @@ function decorateWithOptionsAssertions (fn, assertions) {
   };
 }
 
+const deleteResource = decorateWithOptionsAssertions((options) => {
+  return auth.read()
+    .then((a) => httpUtils.sendRequest({
+      credential: a.credential,
+      method: 'DELETE',
+      url: `${a.origin}/_api/v1/${options.type}/${options.id}`
+    }));
+}, [
+  assertIdOption,
+  assertTypeOption,
+  assertKnownTypeOption
+]);
+
 const getResource = decorateWithOptionsAssertions((options) => {
   return auth.read()
     .then((a) => httpUtils.sendRequest({

--- a/lib/api.js
+++ b/lib/api.js
@@ -108,6 +108,7 @@ const putResource = decorateWithOptionsAssertions((options) => {
 ]);
 
 module.exports = {
+  deleteResource,
   getDashboard,
   getResource,
   putResource,

--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -73,13 +73,39 @@ function deployInteractions (options) {
     })));
 }
 
-function deployAll () {
+function deployAll (options) {
+  options = options || {};
   const cwd = process.env.BMP_WORKING_DIR || process.cwd();
 
   return Promise.all([
     deployAnswerSpace({ cwd }),
     deployInteractions({ cwd })
-  ]);
+  ])
+    .then(() => {
+      if (options.prune) {
+        return pruneInteractions({ cwd });
+      }
+    });
+}
+
+function pruneInteractions (options) {
+  return api.getDashboard()
+    .then((obj) => obj.answerSpace.id)
+    .then((id) => Promise.all([
+      api.getResource({ id, type: 'answerspaces' }),
+      resource.listInteractions({ cwd: options.cwd })
+    ]))
+    .then((results) => {
+      const remoteIds = results[0].answerspaces.links.interactions || [];
+      const localIds = results[1].map((i) => i.id);
+      const pruneIds = remoteIds.filter((id) => localIds.indexOf('' + id) === -1);
+      progress.addWork(pruneIds.length);
+      return pruneIds;
+    })
+    .then((pruneIds) => asyncp.eachLimit(pruneIds, values.MAX_REQUESTS, asyncp.asyncify((id) => {
+      return api.deleteResource({ id, type: 'interactions' })
+        .then(() => progress.completeWork(1));
+    })));
 }
 
 module.exports = {

--- a/lib/utils/http.js
+++ b/lib/utils/http.js
@@ -49,7 +49,7 @@ function sendRequest (options) {
         reject(err);
         return;
       }
-      if (!~[200, 201].indexOf(res.statusCode)) {
+      if (!~[200, 201, 204].indexOf(res.statusCode)) {
         reject(new Error(res.statusCode));
         console.error(options.url, res.statusCode, body);
         return;


### PR DESCRIPTION
### Added

- BC-15: implement `blinkm bmp deploy --prune` (#12, @jokeyrhyme)

- copy `--help` documentation out to README.md


### Code Review Notes

- skip / ignore BC-10, BC-13 and BC-11 commits, as they'll be rebased out

- very satisfying to see all previous refactoring has paid off