### PR TITLE
BC-18 # do not attempt to deploy extra files

### DIFF
--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -1,14 +1,8 @@
 'use strict';
 
-// Node.js built-ins
-
-const fs = require('fs');
-const path = require('path');
-
 // foreign modules
 
 const memoize = require('lodash.memoize');
-const pify = require('pify');
 
 // local modules
 
@@ -19,8 +13,6 @@ const resource = require('./resource');
 const values = require('./values');
 
 // this module
-
-const fsp = pify(fs);
 
 const readCachedAnswerSpace = memoize(resource.readAnswerSpace);
 
@@ -54,23 +46,16 @@ function deployInteraction (options) {
 }
 
 function deployInteractions (options) {
-  const cwd = options.cwd;
-  return fsp.readdir(path.join(cwd, 'interactions'))
-    .catch((err) => {
-      if (err.code === 'ENOENT') {
-        // it's not an error condition if we don't have any interactions
-        return [];
-      }
-      throw err;
-    })
-    .then((names) => {
-      progress.addWork(names.length);
-      return names;
-    })
-    .then((names) => asyncp.eachLimit(names, values.MAX_REQUESTS, asyncp.asyncify((name) => {
-      return deployInteraction({ cwd, name })
-        .then(() => progress.completeWork(1));
-    })));
+  return resource.listInteractions(options)
+    .then((results) => results.map((result) => result.name))
+    .then((names) => asyncp.eachLimit(
+      names,
+      values.MAX_REQUESTS,
+      asyncp.asyncify((name) => {
+        return deployInteraction({ cwd: options.cwd, name })
+          .then(() => progress.completeWork(1));
+      })
+    ));
 }
 
 function deployAll (options) {

--- a/test/deploy.js
+++ b/test/deploy.js
@@ -56,7 +56,8 @@ test.serial('deployAll', (t) => {
   })
     .then(() => mkdirp(path.join(t.context.tempDir, 'interactions', 'test')))
     .then(() => writeJson(path.join(t.context.tempDir, 'interactions', 'test', 'test.json'), {
-      id: '456'
+      id: '456',
+      name: 'test'
     }))
     .then(() => deploy.deployAll());
 });
@@ -90,4 +91,24 @@ test.serial('deployAll --prune', (t) => {
       name: 'def'
     }))
     .then(() => deploy.deployAll({ prune: true }));
+});
+
+test.serial('deployAll with .DS_Store files', (t) => {
+  const tempDir = t.context.tempDir;
+  reqFn = oneInteraction;
+  return Promise.all([
+    writeJson(path.join(tempDir, 'answerSpace.json'), {
+      id: '123'
+    }),
+    writeJson(path.join(tempDir, 'interactions', 'test', 'test.json'), {
+      id: '456',
+      name: 'test'
+    })
+  ])
+    .then(() => Promise.all([
+      writeJson(path.join(tempDir, '.DS_Store'), {}),
+      writeJson(path.join(tempDir, 'interactions', '.DS_Store'), {}),
+      writeJson(path.join(tempDir, 'interactions', 'test', '.DS_Store'), {})
+    ]))
+    .then(() => deploy.deployAll());
 });


### PR DESCRIPTION
### Fixed

- BC-18: do not attempt to deploy extra files, e.g. .DS_Store, etc (#15, @jokeyrhyme)


### Code Review Notes

- we already had a smarter / stricter function for listing local interactions, so I just switched to that for `deploy`, easy