### PR TITLE
run @jokeyrhyme/node-init; add greenkeeper

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ node_modules
 # temporary files
 /.blinkmrc.json
 /blinkmrc.json
+
+.eslintcache

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,18 @@
 language: node_js
 node_js:
-  - "4"
-  - "stable"
+  - '4'
+  - '5'
+  - '6'
 sudo: false
+env:
+  global:
+    - CXX=g++-4.8
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.8
+cache:
+  directories:
+    - node_modules

--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
-# blinkmobile/bmp-cli
+# blinkmobile/bmp-cli [![npm module](https://img.shields.io/npm/v/@blinkmobile/bmp-cli.svg)](https://www.npmjs.com/package/@blinkmobile/bmp-cli) [![Build Status](https://travis-ci.org/blinkmobile/bmp-cli.svg?branch=master)](https://travis-ci.org/blinkmobile/bmp-cli) [![AppVeyor Status](https://ci.appveyor.com/api/projects/status/github/blinkmobile/bmp-cli?branch=master&svg=true)](https://ci.appveyor.com/project/blinkmobile/bmp-cli)
 
 CLI utility for BlinkMobile's Mobility Platform
-
-[![npm module](https://img.shields.io/npm/v/@blinkmobile/bmp-cli.svg)](https://www.npmjs.com/package/@blinkmobile/bmp-cli)
-[![Build Status](https://travis-ci.org/blinkmobile/bmp-cli.svg?branch=master)](https://travis-ci.org/blinkmobile/bmp-cli)
 
 
 ## Installation

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,15 @@
+build: 'off'
+environment:
+  matrix:
+    - nodejs_version: '4'
+    - nodejs_version: '5'
+    - nodejs_version: '6'
+install:
+  - ps: 'Install-Product node $env:nodejs_version'
+  - npm install
+test_script:
+  - node --version
+  - npm --version
+  - npm test
+cache:
+  - node_modules

--- a/package.json
+++ b/package.json
@@ -39,10 +39,15 @@
     "eslint-plugin-promise": "^1.1.0",
     "eslint-plugin-standard": "^1.3.1",
     "fixpack": "^2.2.0",
+    "greenkeeper-postpublish": "1.0.0",
     "mockery": "^1.4.0",
     "npm-run-all": "^2.1.0",
     "nyc": "^6.0.0",
     "temp": "^0.8.3"
+  },
+  "directories": {
+    "doc": "docs",
+    "test": "test"
   },
   "engines": {
     "node": ">=4.0.0",
@@ -58,16 +63,20 @@
   "keywords": [],
   "license": "BSD-3-Clause",
   "main": "index.js",
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/blinkmobile/bmp-cli.git"
   },
   "scripts": {
     "ava": "nyc ava",
-    "eslint": "eslint .",
+    "eslint": "eslint --fix --cache .",
     "fixpack": "fixpack",
     "nyc": "nyc check-coverage -s 80 -b 50 -f 80 -l 80",
     "posttest": "npm-run-all eslint fixpack",
-    "test": "npm-run-all -s ava nyc"
+    "test": "npm-run-all -s ava nyc",
+    "postpublish": "greenkeeper-postpublish"
   }
 }


### PR DESCRIPTION
### Added

- use [AppVeyor](http://www.appveyor.com/) for CI on Windows

- use [Greenkeeper](https://greenkeeper.io/) for automated dependency updates via PRs

- settings for [EditorConfig](http://editorconfig.org/) for cross-IDE consistency


### Changed

- optimisations and improvements to [Travis CI](https://travis-ci.org/) integration

- more consistent and thorough package.json


### Code Review Notes

- much of the above was achieved by running [@jokeyrhyme/node-init](https://github.com/jokeyrhyme/node-init), and making minor project-specific tweaks to some of the changes

- Greenkeeper is a separate integration process so far