### PR TITLE
BC-29 # bump deps

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,5 @@
 {
-  "extends": ["eslint:recommended", "semistandard"],
+  "extends": ["eslint:recommended", "standard"],
   "env": {
     "node": true
   },
@@ -7,6 +7,10 @@
     "ecmaVersion": 6
   },
   "rules": {
-    "no-console": 0
+    "no-console": 0,
+
+    "semi": [2, "always"],
+    "no-extra-semi": 2,
+    "semi-spacing": [2, { "before": false, "after": true }]
   }
 }

--- a/lib/utils/asyncp.js
+++ b/lib/utils/asyncp.js
@@ -15,15 +15,17 @@ module.exports = pify(async, {
   exclude: [
     // https://www.npmjs.com/package/async#utils
     'apply',
-    'nextTick',
-    'memoize',
-    'unmemoize',
-    'ensureAsync',
-    'constant',
     'asyncify',
-    'wrapSync',
-    'log',
+    'constant',
     'dir',
-    'noConflict'
+    'ensureAsync',
+    'log',
+    'memoize',
+    'nextTick',
+    'reflect',
+    'reflectAll',
+    'setImmediate',
+    'timeout',
+    'unmemoize'
   ]
 });

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@blinkmobile/json-as-files": "1.1.1",
     "appdirectory": "0.1.0",
     "are-we-there-yet": "1.1.2",
-    "async": "1.5.2",
+    "async": "2.0.1",
     "elegant-spinner": "1.0.1",
     "find-up": "1.1.2",
     "gauge": "2.6.0",

--- a/package.json
+++ b/package.json
@@ -26,20 +26,19 @@
     "mkdirp": "0.5.1",
     "pify": "2.3.0",
     "prompt": "1.0.0",
-    "request": "2.73.0",
+    "request": "2.74.0",
     "rimraf": "2.5.4",
     "update-notifier": "1.0.2",
     "write-json-file": "2.0.0"
   },
   "devDependencies": {
     "ava": "^0.16.0",
-    "eslint": "^2.7.0",
-    "eslint-config-semistandard": "^6.0.1",
-    "eslint-config-standard": "^5.1.0",
-    "eslint-plugin-promise": "^1.1.0",
-    "eslint-plugin-standard": "^1.3.1",
+    "eslint": "^3.2.2",
+    "eslint-config-standard": "^5.3.5",
+    "eslint-plugin-promise": "^2.0.1",
+    "eslint-plugin-standard": "^2.0.0",
     "fixpack": "^2.2.0",
-    "greenkeeper-postpublish": "1.0.0",
+    "greenkeeper-postpublish": "^1.0.0",
     "mockery": "^1.4.0",
     "npm-run-all": "^2.1.0",
     "nyc": "^7.0.0",
@@ -75,8 +74,8 @@
     "eslint": "eslint --fix --cache .",
     "fixpack": "fixpack",
     "nyc": "nyc check-coverage -s 80 -b 50 -f 80 -l 80",
+    "postpublish": "greenkeeper-postpublish",
     "posttest": "npm-run-all eslint fixpack",
-    "test": "npm-run-all -s ava nyc",
-    "postpublish": "greenkeeper-postpublish"
+    "test": "npm-run-all -s ava nyc"
   }
 }


### PR DESCRIPTION
### Security

- addressed security advisory: https://snyk.io/vuln/npm:tough-cookie:20160722


### Changed

- bumped [async](https://www.npmjs.com/package/async) to 2.0.1 (#61, @jokeyrhyme)

- bumped [request](https://www.npmjs.com/package/request) to 2.74.0


### Code Review Notes

- also bump ESLint, etc

- dropped ESLint SemiStandard in favour of embedding the rules directly, as there are currently some peerDependency version constraints that make things tricky