### PR TITLE
use "npm-bin-ava-tester" package to test CLI

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "fixpack": "^2.2.0",
     "greenkeeper-postpublish": "^1.0.0",
     "mockery": "^1.4.0",
+    "npm-bin-ava-tester": "^1.0.0",
     "npm-run-all": "^3.0.0",
     "nyc": "^8.1.0",
     "temp": "^0.8.3"

--- a/test/cli.js
+++ b/test/cli.js
@@ -1,0 +1,10 @@
+'use strict';
+
+// foreign modules
+
+const npmBinTester = require('npm-bin-ava-tester');
+const test = require('ava');
+
+// local modules
+
+npmBinTester(test);


### PR DESCRIPTION
### Changed

- ensure Node.js CLI conventions are followed with [npm-bin-ava-tester](https://github.com/jokeyrhyme/npm-bin-ava-tester.js)