### PR TITLE
BC-36 # bump blinkmobile/json-as-files to 1.2.1

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,14 +1,9 @@
 {
-  "extends": ["eslint:recommended", "standard"],
+  "extends": ["eslint:recommended", "semistandard"],
   "env": {
     "node": true
   },
   "parserOptions": {
     "ecmaVersion": 6
-  },
-  "rules": {
-    "semi": [2, "always"],
-    "no-extra-semi": 2,
-    "semi-spacing": [2, { "before": false, "after": true }]
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 # Change Log
 
 
+## Unreleased
+
+
+### Fixed
+
+-   bump [blinkmobile/json-as-files](https://github.com/blinkmobile/json-as-files.js/releases/tag/1.2.1) to 1.2.1 (@jokeyrhyme)
+
+    -   fixes "TypeError: Expected a plain object" when trying to extract `null`
+
+    -   HelpDesk: 3691-FKCN-9070
+
+
 ## 1.1.0 - 2016-08-29
 
 

--- a/package.json
+++ b/package.json
@@ -32,8 +32,9 @@
   },
   "devDependencies": {
     "ava": "^0.16.0",
-    "eslint": "^3.2.2",
-    "eslint-config-standard": "^5.3.5",
+    "eslint": "^3.5.0",
+    "eslint-config-semistandard": "^7.0.0",
+    "eslint-config-standard": "^6.0.0",
     "eslint-plugin-promise": "^2.0.1",
     "eslint-plugin-standard": "^2.0.0",
     "fixpack": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@blinkmobile/blinkmrc": "1.1.0",
-    "@blinkmobile/json-as-files": "1.2.0",
+    "@blinkmobile/json-as-files": "1.2.1",
     "are-we-there-yet": "1.1.2",
     "argv-auto-glob": "1.0.1",
     "async": "2.0.1",


### PR DESCRIPTION
### Fixed

-   bump [blinkmobile/json-as-files](https://github.com/blinkmobile/json-as-files.js/releases/tag/1.2.1) to 1.2.1 (@jokeyrhyme)

    -   fixes "TypeError: Expected a plain object" when trying to extract `null`

    -   HelpDesk: 3691-FKCN-9070